### PR TITLE
fix: include type_=All to expand comments

### DIFF
--- a/src/lib/components/lemmy/comment/Comments.svelte
+++ b/src/lib/components/lemmy/comment/Comments.svelte
@@ -43,6 +43,7 @@
         auth: $authData?.token,
         max_depth: 5,
         parent_id: parent.comment_view.comment.id,
+        type_: 'All',
       })
 
       if (newComments.comments.length == 0) {


### PR DESCRIPTION
Further fix #11 by specifying the type_ parameter to 'All'.  Without this, the server returns an empty comments array.