### PR TITLE
fix: add onchange for Communities TextInput

### DIFF
--- a/src/lib/components/input/TextInput.svelte
+++ b/src/lib/components/input/TextInput.svelte
@@ -38,6 +38,7 @@
     bind:value
     on:keydown={(e) => dispatcher('keydown', e)}
     on:input={(e) => dispatcher('input', e)}
+    on:change={(e) => dispatcher('change', e)}
     {...$$restProps}
     class={className}
     {required}

--- a/src/routes/communities/+page.svelte
+++ b/src/routes/communities/+page.svelte
@@ -37,7 +37,14 @@
     }}
   />
   <div class="flex flex-col sm:flex-row gap-2 sm:ml-auto items-center">
-    <TextInput bind:value={search} />
+    <TextInput bind:value={search}
+      on:change={() => {
+        $page.url.searchParams.set('q', search)
+        goto($page.url.toString(), {
+          invalidateAll: true,
+        })
+      }}
+    />
     <Button
       on:click={() => {
         $page.url.searchParams.set('q', search)


### PR DESCRIPTION
This allows the user to simply enter in their filter and press enter, rather than having to press the "Search" button.