### PR TITLE
fix: allow UI settings to persist

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -27,21 +27,12 @@ const defaultSettings: Settings = {
 
 export const userSettings = writable(defaultSettings)
 
-function mergeObjects<T>(obj1: any, obj2: any): T {
-  for (let prop in obj2) {
-    if (!(prop in obj1) || obj1[prop] == null || obj2[prop] == '') {
-      obj1[prop] = obj2[prop]
-    }
-  }
-  return obj1
-}
-
 if (typeof window != 'undefined') {
   let oldUserSettings = JSON.parse(
     localStorage.getItem('settings') ?? JSON.stringify(defaultSettings)
   )
 
-  userSettings.set(mergeObjects<Settings>(oldUserSettings, defaultSettings))
+  userSettings.set({...defaultSettings, ...oldUserSettings})
 }
 
 userSettings.subscribe((settings) => {


### PR DESCRIPTION
UI settings were being overwritten on refresh. Changing this check appears to resolve this issue and allows for the UI settings to persist.