### PR TITLE
feat: show compact posts

### DIFF
--- a/src/lib/components/lemmy/post/Post.svelte
+++ b/src/lib/components/lemmy/post/Post.svelte
@@ -15,34 +15,62 @@
 </script>
 
 <Card class="bg-white flex flex-col w-full p-5 gap-2.5">
-  <PostMeta
-    community={post.community}
-    user={post.creator}
-    published={new Date(post.post.published)}
-    upvotes={post.counts.upvotes}
-    downvotes={post.counts.downvotes}
-    deleted={post.post.deleted}
-    featured={post.post.featured_local || post.post.featured_community}
-    nsfw={post.post.nsfw}
-    saved={post.saved}
-  />
-  <a
-    href="/post/{getInstance()}/{post.post.id}"
-    class="font-bold"
-    class:opacity-50={post.read && $userSettings.markReadPosts}
-  >
-    {post.post.name}
-  </a>
-  {#if post.post.url && !post.post.thumbnail_url}
-    <a
-      href={post.post.url}
-      class="max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap text-sky-400 hover:underline text-xs"
-    >
-      {post.post.url}
-    </a>
-  {/if}
-  {#if isImage(post.post.url)}
-    <div class="self-start" class:blur-3xl={post.post.nsfw}>
+  <div class="flex flex-row w-full gap-2.5">
+    <div class="flex flex-col gap-2.5 grow">
+      <PostMeta
+        community={post.community}
+        user={post.creator}
+        published={new Date(post.post.published)}
+        upvotes={post.counts.upvotes}
+        downvotes={post.counts.downvotes}
+        deleted={post.post.deleted}
+        featured={post.post.featured_local || post.post.featured_community}
+        nsfw={post.post.nsfw}
+        saved={post.saved}
+      />
+      <a
+        href="/post/{getInstance()}/{post.post.id}"
+        class="font-bold"
+        class:opacity-50={post.read && $userSettings.markReadPosts}
+      >
+        {post.post.name}
+      </a>
+    </div>
+    {#if $userSettings.showCompactPosts && (post.post.thumbnail_url || isImage(post.post.url))}
+      <div class="flex-none w-24 h-24">
+        <a
+          href="/post/{getInstance()}/{post.post.id}"
+        >
+          {#if post.post.thumbnail_url}
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <img
+            src="{post.post.thumbnail_url}?thumbnail=256&format=webp"
+            loading="lazy"
+            class="object-cover bg-slate-100 rounded-md h-24 w-24 border border-slate-200 dark:border-zinc-700"
+          />
+          {:else}
+          <!-- svelte-ignore a11y-missing-attribute -->
+          <img
+            src="{post.post.url}?thumbnail=256&format=webp"
+            loading="lazy"
+            class="object-cover bg-slate-100 rounded-md h-24 w-24 border border-slate-200 dark:border-zinc-700"
+          />
+          {/if}
+        </a>
+      </div>
+    {/if}
+  </div>
+  {#if !$userSettings.showCompactPosts}
+    {#if post.post.url && !post.post.thumbnail_url}
+      <a
+        href={post.post.url}
+        class="max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap text-sky-400 hover:underline text-xs"
+      >
+        {post.post.url}
+      </a>
+    {/if}
+    {#if isImage(post.post.url)}
+      <div class="self-start" class:blur-3xl={post.post.nsfw}>
       <picture
         class="rounded-md overflow-hidden max-h-[min(50vh,500px)] w-full max-w-full"
       >
@@ -67,21 +95,22 @@
           height={300}
         />
       </picture>
-    </div>
-  {:else if post.post.thumbnail_url && post.post.url}
-    <PostLink
-      url={post.post.url}
-      thumbnail_url={post.post.thumbnail_url}
-      nsfw={post.post.nsfw}
-    />
-  {/if}
-  {#if post.post.body && !post.post.nsfw}
-    <p
-      class="text-sm max-h-[74px] line-clamp-3 bg-slate-100 dark:bg-zinc-800
-        border border-slate-200 dark:border-zinc-700 rounded-md p-2"
-    >
-      {post.post.body}
-    </p>
+      </div>
+    {:else if post.post.thumbnail_url && post.post.url}
+      <PostLink
+        url={post.post.url}
+        thumbnail_url={post.post.thumbnail_url}
+        nsfw={post.post.nsfw}
+      />
+    {/if}
+    {#if post.post.body && !post.post.nsfw}
+      <p
+        class="text-sm max-h-[74px] line-clamp-3 bg-slate-100 dark:bg-zinc-800
+            border border-slate-200 dark:border-zinc-700 rounded-md p-2"
+      >
+        {post.post.body}
+      </p>
+    {/if}
   {/if}
   <PostActions
     {post}

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -7,6 +7,7 @@ interface Settings {
   instance?: string
   revertColors: boolean
   showInstance: boolean
+  showCompactPosts: boolean
   defaultSort: {
     sort: 'Hot' | 'TopAll' | 'Active' | 'New'
     feed: 'All' | 'Subscribed' | 'Local'
@@ -19,6 +20,7 @@ const defaultSettings: Settings = {
   markReadPosts: true,
   revertColors: false,
   showInstance: false,
+  showCompactPosts: false,
   defaultSort: {
     sort: 'Active',
     feed: 'Local',

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -114,4 +114,9 @@
     </span>
     <Switch bind:enabled={$userSettings.showInstance} />
   </Setting>
+  <Setting>
+    <span slot="title">Show compact posts</span>
+    <span slot="description">Show posts with smaller thumbnails and without text bodies.</span>
+    <Switch bind:enabled={$userSettings.showCompactPosts} />
+  </Setting>
 </div>


### PR DESCRIPTION
Add a new UI setting for showing compact posts:

- Show a small thumbnail to the right of the metadata and title if a thumbnail is available or if the post is an image
- Do not show normal thumbnail or text bodies.

Here is a screenshot of what the Frontpage looks like on the desktop (Firefox):

![Screenshot from 2023-07-26 10-02-06](https://github.com/Xyphyn/photon/assets/3976244/c686b0b3-cdf5-4787-affc-c71de3a27837)

Here is a community screenshot:

![Screenshot from 2023-07-26 10-04-33](https://github.com/Xyphyn/photon/assets/3976244/4edc0b79-704c-4085-8735-16719c458880)

Here is the Frontpage on mobile (Firefox/Android):

![le6g](https://github.com/Xyphyn/photon/assets/3976244/2b491e05-0a6a-41d8-b6d0-7d8d16c651c5)

Here is a community screenshot on mobile:

![gSOk](https://github.com/Xyphyn/photon/assets/3976244/8f73edf0-53d3-4044-9748-d6d3718dfa2c)

If you need me to refactor or modify the code, I would welcome the opportunity to do so.  Thanks for starting this great project!