### PR TITLE
fix: show post.url if the post does not have a thumbnail

### DIFF
--- a/src/routes/post/[instance]/[id]/+page.svelte
+++ b/src/routes/post/[instance]/[id]/+page.svelte
@@ -92,7 +92,14 @@
     saved={postData.saved}
   />
   <h1 class="font-bold text-lg">{post.name}</h1>
-  {#if isImage(post.url)}
+  {#if post.url && !post.thumbnail_url}
+    <a
+      href={post.url}
+      class="max-w-full overflow-hidden overflow-ellipsis whitespace-nowrap text-sky-400 hover:underline text-xs"
+    >
+      {post.url}
+    </a>
+  {:else if isImage(post.url)}
     <img
       src={post.url}
       alt={post.name}


### PR DESCRIPTION
Right now, if a post does not have a post.thumbnail_url and is just a link to another website, the link is not displayed... so the user cannot go to the actual article.

This copies the link code from the Post object and provides a link if there is a post.url but not a post.thumbnail_url.

An example of this is here:

https://nu.lemdro.id/post/lemmy.world/2164687

There is no thumbnail, so there is no link for the user to click on to visit the article.