### PR TITLE
fix: only list/search subscribed communities

### DIFF
--- a/src/lib/components/lemmy/post/PostForm.svelte
+++ b/src/lib/components/lemmy/post/PostForm.svelte
@@ -68,7 +68,7 @@
 
     const list = await getClient().listCommunities({
       auth: $authData?.token,
-      type_: 'All',
+      type_: 'Subscribed',
       sort: 'Active',
       limit: 40,
     })
@@ -157,6 +157,7 @@
             auth: $authData?.token,
             type_: 'Communities',
             limit: 20,
+            listing_type: 'Subscribed',
             sort: 'Active',
           })
 


### PR DESCRIPTION
Right now, listing and searching 'All' communities makes it difficult to find the appropriate community to post to, particularly if it has a common name such as technology, news, or linux.

Downside of this is that you can only post to communities you subscribe to... but this was what we did before 9c9a3dc.