### PR TITLE
fix: properly load comments when sorting

### DIFF
--- a/src/routes/post/[instance]/[id]/+page.svelte
+++ b/src/routes/post/[instance]/[id]/+page.svelte
@@ -61,6 +61,7 @@
       max_depth: 3,
       page: commentsPage,
       limit: 25,
+      type_: 'All',
       post_id: data.post.post_view.post.id,
       sort: commentSort,
     })
@@ -203,6 +204,7 @@
             max_depth: 3,
             page: ++commentsPage,
             limit: 25,
+            type_: 'All',
             post_id: data.post.post_view.post.id,
           })
 


### PR DESCRIPTION
Need to set type_ to 'All' when calling getComments().  Otherwise, trying sort the comments on a post by "Top" or "New" will refresh without any comments.