### PR TITLE
Use unprivileged "node" user in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,8 @@ COPY . .
 
 RUN ADAPTER=node npm run build
 
+RUN chown -R node /app
+
+USER node
+
 CMD ["npm", "run", "start"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ COPY . .
 
 RUN ADAPTER=node npm run build
 
-RUN chown -R node /app
-
 USER node
 
 CMD ["npm", "run", "start"]


### PR DESCRIPTION
The official node image has a user already built-in expressly for this purpose.