### PR TITLE
fix: parse date strings as UTC

### DIFF
--- a/src/lib/components/lemmy/SiteCard.svelte
+++ b/src/lib/components/lemmy/SiteCard.svelte
@@ -33,7 +33,7 @@
   </div>
   <span class="flex flex-row items-center gap-1 text-sm">
     <Icon src={Calendar} width={16} height={16} mini />
-    <RelativeDate date={new Date(site.site.published)} />
+    <RelativeDate date={new Date(site.site.published + 'Z')} />
   </span>
   <div class="text-sm flex flex-row flex-wrap gap-3">
     <span class="flex flex-row items-center gap-1">

--- a/src/lib/components/lemmy/comment/Comment.svelte
+++ b/src/lib/components/lemmy/comment/Comment.svelte
@@ -101,7 +101,7 @@
             {node.comment_view.counts.score}
           </div>
         {/if}
-        <RelativeDate date={new Date(node.comment_view.comment.published)} />
+        <RelativeDate date={new Date(node.comment_view.comment.published + 'Z')} />
         <span>•</span>
         <span>
           {Math.floor(

--- a/src/lib/components/lemmy/comment/CommentItem.svelte
+++ b/src/lib/components/lemmy/comment/CommentItem.svelte
@@ -16,7 +16,7 @@
       deleted={false}
       featured={false}
       nsfw={comment.post.nsfw}
-      published={new Date(comment.post.published)}
+      published={new Date(comment.post.published + 'Z')}
       saved={false}
     />
     <Button

--- a/src/lib/components/lemmy/community/CommunityCard.svelte
+++ b/src/lib/components/lemmy/community/CommunityCard.svelte
@@ -87,7 +87,7 @@
   </div>
   <span class="flex flex-row items-center gap-1 text-sm">
     <Icon src={Calendar} width={16} height={16} mini />
-    <RelativeDate date={new Date(community_view.community.published)} />
+    <RelativeDate date={new Date(community_view.community.published + 'Z')} />
   </span>
   <div class="text-sm flex flex-row flex-wrap gap-3">
     <span class="flex flex-row items-center gap-1">

--- a/src/lib/components/lemmy/post/Post.svelte
+++ b/src/lib/components/lemmy/post/Post.svelte
@@ -22,7 +22,7 @@
       <PostMeta
         community={post.community}
         user={post.creator}
-        published={new Date(post.post.published)}
+        published={new Date(post.post.published + 'Z')}
         upvotes={post.counts.upvotes}
         downvotes={post.counts.downvotes}
         deleted={post.post.deleted}

--- a/src/routes/post/[instance]/[id]/+page.svelte
+++ b/src/routes/post/[instance]/[id]/+page.svelte
@@ -107,7 +107,7 @@
     locked={postData.post.locked}
     featured={postData.post.featured_community || postData.post.featured_local}
     nsfw={postData.post.nsfw}
-    published={new Date(postData.post.published)}
+    published={new Date(postData.post.published + 'Z')}
     saved={postData.saved}
   />
   <h1 class="font-bold text-lg">{post.name}</h1>

--- a/src/routes/u/[name]/+page.svelte
+++ b/src/routes/u/[name]/+page.svelte
@@ -183,7 +183,7 @@
       <span class="flex flex-row items-center gap-1 text-sm">
         <Icon src={Calendar} width={16} height={16} mini />
         <span class="capitalize">
-          <RelativeDate date={new Date(data.person_view.person.published)} />
+          <RelativeDate date={new Date(data.person_view.person.published + 'Z')} />
         </span>
       </span>
       <div class="text-sm flex flex-row flex-wrap gap-3">


### PR DESCRIPTION
# Issue

Here is the same lemmy post shown by lemmy-ui and by photon:

- [lemmy-ui](https://lemmy.ndlug.org/post/1612)
- [photon](https://photon.ndlug.org/post/lemmy.ndlug.org/1612)

Depending on your local timezone, the relative time since the post will display differently for the two frontends. At the time of writing, lemmy-ui shows me "8 hours ago" (correct) while photon shows me "4h ago" (incorrect). I made the post myself around 12:38 EDT, which is 8 hours ago. Photon is off by 4 hours because my local time is UTC-04:00.

# Cause and fix

For posts, comments, and other objects, the `published` attribute is a string containing an ISO 8601 timestamp. This timestamp is UTC, though it is not explicit in the string's contents. When the `Date` constructor is used on such strings, they are parsed as though they are local timestamps. According to MDN[^1]:

> When the time zone offset is absent, date-only forms are
> interpreted as a UTC time and date-time forms are interpreted as local
> time. This is due to a historical spec error that was not consistent
> with ISO 8601 but could not be changed due to web
> compatibility.

This patch explicitly appends a 'Z' to the `published` string when it is used as the argument to the `Date` constructor.

[^1]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date