### PR TITLE
feat: hover on relative datetimes

### DIFF
--- a/src/lib/components/util/RelativeDate.svelte
+++ b/src/lib/components/util/RelativeDate.svelte
@@ -35,4 +35,6 @@
   }
 </script>
 
-{formatRelativeDate(date)}
+<time datetime={date.toISOString()} title={date}>
+  {formatRelativeDate(date)}
+</time>


### PR DESCRIPTION
Relative datetimes (e.g. "42m ago") are displayed for posts, comments, user pages, community cards, and site cards. This patch wraps these relative datetimes in a `<time>` tag which has a `title` attribute and an ISO 8601 `datetime` attribute. The `title` allows users to see a full, non-relative timestamp when hovering with the mouse.

This is a feature that Reddit, tildes.net, and lemmy-ui have.