### PR TITLE
fix: improve building comment tree

### DIFF
--- a/src/lib/components/lemmy/comment/Comments.svelte
+++ b/src/lib/components/lemmy/comment/Comments.svelte
@@ -59,7 +59,7 @@
         return
       }
 
-      const tree = buildCommentsTree(newComments.comments, false)
+      const tree = buildCommentsTree(newComments.comments, parent.depth)
 
       // 0.18.2 -> 0.18.3 broke this
       // so i'm adding this check


### PR DESCRIPTION
As we build the map of nodes, keep track of the minimum depth level. Afterwards, nodes at the minimum depth level go into the tree as the roots.

We no longer need to check if the tree belongs to a parent comment or not.

Fixes #36 more.