### PR TITLE
misc: allow replies to use max width (instead of small)

### DIFF
--- a/src/lib/components/lemmy/comment/Comment.svelte
+++ b/src/lib/components/lemmy/comment/Comment.svelte
@@ -159,7 +159,7 @@
       {/if}
     </div>
     {#if replying}
-      <div class="max-w-sm my-2">
+      <div class="max-w-full my-2">
         <h1 class="font-bold text-sm mb-2">Reply</h1>
         <CommentForm
           {postId}


### PR DESCRIPTION
I often find myself resizing the textarea when replying to comments, so I was wondering if we can allow the replies textarea to use the full width just like the comment box at the top of the post.

Here is a screenshot demonstrating the difference (top is current, bottom is with change):

![Screenshot from 2023-07-29 18-43-24](https://github.com/Xyphyn/photon/assets/3976244/57609bcf-c8ea-482c-9f2c-f981804be63d)
