### PR TITLE
fix: force navbar avatar to be square

### DIFF
--- a/src/lib/components/ui/Navbar.svelte
+++ b/src/lib/components/ui/Navbar.svelte
@@ -129,7 +129,7 @@
           alt=""
           width={32}
           height={32}
-          class="rounded-full"
+          class="rounded-full aspect-square"
         />
         {#if $user.unreads > 0}
           <div class="rounded-full w-2 h-2 bg-red-500 absolute top-0 left-0" />


### PR DESCRIPTION
Though the width and height attributes are set to 32 in this component, the height is overridden by the more general styling for `<img>` tags, which sets image heights to `auto`. For users with non-square avatars, their avatar may overflow beyond its ring border. Specify the `aspect-square` class to force a 1:1 aspect ratio. The Avatar component used for posts, comments, etc. already does this.

---

Before:
![fix-before](https://github.com/Xyphyn/photon/assets/47096018/75aa59a1-5d1d-42d6-bec5-fa59492e9972)

After:
![fix-after](https://github.com/Xyphyn/photon/assets/47096018/8f82279d-4c1f-48f9-bd70-e1c013bf5294)