### PR TITLE
misc: set different disabled backgrounds for light and dark mode

### DIFF
--- a/src/lib/components/input/TextInput.svelte
+++ b/src/lib/components/input/TextInput.svelte
@@ -17,7 +17,7 @@
     ${value.length != 0 ? 'invalid:border-red-400' : ''}
     w-full px-3 text-sm py-2.5 bg-white dark:bg-zinc-950
     border border-slate-300 dark:border-zinc-700 dark:focus:border-white
-    focus:outline-none focus:border-black transition-colors rounded-md disabled:bg-slate-200 disabled:bg-zinc-800 disabled:opacity-70
+    focus:outline-none focus:border-black transition-colors rounded-md disabled:bg-slate-200 disabled:bg-zinc-300 dark:disabled:bg-zinc-800 disabled:opacity-70
     ${$$props.class}
   `
 </script>

--- a/src/lib/components/input/TextInput.svelte
+++ b/src/lib/components/input/TextInput.svelte
@@ -17,7 +17,7 @@
     ${value.length != 0 ? 'invalid:border-red-400' : ''}
     w-full px-3 text-sm py-2.5 bg-white dark:bg-zinc-950
     border border-slate-300 dark:border-zinc-700 dark:focus:border-white
-    focus:outline-none focus:border-black transition-colors rounded-md disabled:bg-slate-200 disabled:bg-zinc-300 dark:disabled:bg-zinc-800 disabled:opacity-70
+    focus:outline-none focus:border-black transition-colors rounded-md disabled:bg-slate-200 disabled:border-slate-300 dark:disabled:border-zinc-600 dark:disabled:bg-zinc-700 disabled:opacity-70
     ${$$props.class}
   `
 </script>


### PR DESCRIPTION
Currently, when the INSTANCE_URL is set, the login with the INSTANCE_URL is unreadable in light mode:

![Screenshot from 2023-07-31 19-57-44](https://github.com/Xyphyn/photon/assets/3976244/7890d808-a4d4-45ef-886a-108f472b27be)

With this change, we set different background colors for dark and light mode.  Here is the new light mode:

![Screenshot from 2023-07-31 19-57-09](https://github.com/Xyphyn/photon/assets/3976244/ea18b7ff-4fff-403b-877f-3f08008f8a50)

and new dark mode:

![Screenshot from 2023-07-31 19-56-49](https://github.com/Xyphyn/photon/assets/3976244/6eeecc5f-172d-4d72-98bf-ac4846b002ff)