### PR TITLE
feat: store sidebar expanded state in settings

### DIFF
--- a/src/lib/components/ui/sidebar/Sidebar.svelte
+++ b/src/lib/components/ui/sidebar/Sidebar.svelte
@@ -11,41 +11,40 @@
   import Button from '../../input/Button.svelte'
   import Avatar from '$lib/components/ui/Avatar.svelte'
   import { profile, profileData, setUserID } from '$lib/auth.js'
+  import { userSettings } from '$lib/settings.js'
   import { goto } from '$app/navigation'
   import { page } from '$app/stores'
   import { slide } from 'svelte/transition'
   import SidebarButton from '$lib/components/ui/sidebar/SidebarButton.svelte'
   import CommunityList from '$lib/components/ui/sidebar/CommunityList.svelte'
-
-  let expanded = true
 </script>
 
 <nav
   class="hidden sm:flex flex-col pl-4 pr-4 py-4 overflow-auto sticky top-16 bottom-0
   gap-1 max-h-[calc(100vh-4rem)] w-full bg-slate-100 dark:bg-black
-  {expanded
+  {$userSettings.expandSidebar
     ? 'max-w-[25%] resize-x min-w-[12rem]'
     : 'w-max max-w-max min-w-max'}"
 >
   <Button
-    on:click={() => (expanded = !expanded)}
+    on:click={() => ($userSettings.expandSidebar = !$userSettings.expandSidebar)}
     class="w-max !p-2 hover:bg-slate-200"
   >
     <Icon
       src={ChevronDoubleLeft}
       mini
       size="16"
-      class="transition-transform {expanded ? '' : 'rotate-180'}"
-      title="Toggle expanded"
+      class="transition-transform {$userSettings.expandSidebar ? '' : 'rotate-180'}"
+      title="Toggle Sidebar"
     />
   </Button>
-  <SidebarButton href="/" {expanded}>
+  <SidebarButton href="/" expanded={$userSettings.expandSidebar}>
     <Icon src={Home} solid size="20" title="Frontpage" />
-    <span class:hidden={!expanded}>Frontpage</span>
+    <span class:hidden={!$userSettings.expandSidebar}>Frontpage</span>
   </SidebarButton>
-  <SidebarButton href="/settings" {expanded}>
+  <SidebarButton href="/settings" expanded={$userSettings.expandSidebar}>
     <Icon src={Cog6Tooth} solid size="20" title="Settings" />
-    <span class:hidden={!expanded}>Settings</span>
+    <span class:hidden={!$userSettings.expandSidebar}>Settings</span>
   </SidebarButton>
   {#if $profileData.profiles.length >= 1}
     <hr class="border-slate-300 dark:border-zinc-800 my-1" />
@@ -59,7 +58,7 @@
             invalidateAll: true,
           })
         }}
-        class="hover:bg-slate-200 {expanded ? '' : '!p-1.5'} {$profile?.id ==
+        class="hover:bg-slate-200 {$userSettings.expandSidebar ? '' : '!p-1.5'} {$profile?.id ==
         prof.id
           ? 'font-bold'
           : ''}"
@@ -72,7 +71,7 @@
           class="text-blue-500"
           style="filter: hue-rotate({index * 50}deg)"
         />
-        <span class:hidden={!expanded} class="flex flex-col gap-0">
+        <span class:hidden={!$userSettings.expandSidebar} class="flex flex-col gap-0">
           {prof.username}
           <span class="text-slate-500 dark:text-zinc-400 font-normal text-xs">
             {prof.instance}
@@ -85,36 +84,36 @@
   {#if $profile?.user}
     {#if $profile?.user.moderates.length > 0}
       <CommunityList
-        {expanded}
+        expanded={$userSettings.expandSidebar}
         items={$profile.user.moderates.map((i) => i.community)}
       />
       <hr class="border-slate-300 dark:border-zinc-800 my-1" />
     {/if}
 
     <CommunityList
-      {expanded}
+      expanded={$userSettings.expandSidebar}
       items={$profile.user.follows.map((i) => i.community)}
     />
     {#if $profile.user.follows.length == 0}
       <Button
-        class="hover:bg-slate-200 {expanded ? '' : '!p-1.5'}"
+        class="hover:bg-slate-200 {$userSettings.expandSidebar ? '' : '!p-1.5'}"
         href="/communities"
         color="tertiary"
         alignment="left"
       >
         <Icon src={Plus} solid size="20" />
-        <span class:hidden={!expanded}>Add communities</span>
+        <span class:hidden={!$userSettings.expandSidebar}>Add communities</span>
       </Button>
     {/if}
   {:else}
     <Button
-      class="hover:bg-slate-200 {expanded ? '' : '!p-1.5'}"
+      class="hover:bg-slate-200 {$userSettings.expandSidebar ? '' : '!p-1.5'}"
       href="/accounts"
       color="tertiary"
       alignment="left"
     >
       <Icon src={ArrowLeftOnRectangle} solid size="20" />
-      <span class:hidden={!expanded}>Log in</span>
+      <span class:hidden={!$userSettings.expandSidebar}>Log in</span>
     </Button>
   {/if}
 </nav>

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -18,6 +18,7 @@ interface Settings {
     feed: 'All' | 'Subscribed' | 'Local'
   }
   fullWidthLayout: boolean
+  expandSidebar: boolean
 }
 
 const defaultSettings: Settings = {
@@ -36,6 +37,7 @@ const defaultSettings: Settings = {
     feed: 'Local',
   },
   fullWidthLayout: false,
+  expandSidebar: true,
 }
 
 export const userSettings = writable(defaultSettings)


### PR DESCRIPTION
Add an expandSidebar setting to remember if the sidebar is expanded or collapsed.  This allows the user to refresh or open a post in a new tab and keep the same sidebar state (rather than it always being expanded).

One possible quirk is that if a user has it collapsed in one tab, but expanded in another, it will remember which ever state was set last (most recently).  However, changing the state in one tab will not impact another (until a refresh occurs).

Fix #68