### PR TITLE
misc: don't let community avatars on sidebar shrink

### DIFF
--- a/src/lib/components/ui/sidebar/CommunityList.svelte
+++ b/src/lib/components/ui/sidebar/CommunityList.svelte
@@ -14,13 +14,15 @@
     alignment="left"
     href="/c/{follow.name}@{new URL(follow.actor_id).hostname}"
   >
-    <Avatar
-      url={follow.icon}
-      alt={follow.name}
-      title={follow.title}
-      width={20}
-      slot="icon"
-    />
+    <div class="flex-none">
+      <Avatar
+        url={follow.icon}
+        alt={follow.name}
+        title={follow.title}
+        width={20}
+        slot="icon"
+      />
+    </div>
     <span class:hidden={!expanded}>
       {follow.title}
     </span>


### PR DESCRIPTION
If a community name is long and uses multiple lines, the avatar will shrink, leading to awkward alignment.

This adds a non-flexible container around the avatar to prevent this.

Before:

![Screenshot from 2023-08-05 10-38-37](https://github.com/Xyphyn/photon/assets/3976244/2fad7f2e-bc0d-4e9a-a208-e274cae164b9)

After:

![Screenshot from 2023-08-05 10-59-33](https://github.com/Xyphyn/photon/assets/3976244/d87ebd77-c8f8-4f67-9679-d361d9e59541)

