### PR TITLE
feat: add ability to hide deleted or removed posts

### DIFF
--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -42,7 +42,7 @@ const defaultSettings: Settings = {
   },
   hidePosts: {
     deleted: true,
-    removed: true,
+    removed: false,
   },
   fullWidthLayout: false,
   expandSidebar: true,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -17,6 +17,10 @@ interface Settings {
     sort: SortType
     feed: 'All' | 'Subscribed' | 'Local'
   }
+  hidePosts: {
+    deleted: boolean,
+    removed: boolean,
+  },
   fullWidthLayout: boolean
   expandSidebar: boolean
 }
@@ -35,6 +39,10 @@ const defaultSettings: Settings = {
   defaultSort: {
     sort: 'Active',
     feed: 'Local',
+  },
+  hidePosts: {
+    deleted: true,
+    removed: true,
   },
   fullWidthLayout: false,
   expandSidebar: true,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -14,6 +14,7 @@
   import { profile } from '$lib/auth.js'
   import Sort from '$lib/components/lemmy/Sort.svelte'
   import { searchParam } from '$lib/util.js'
+  import { userSettings } from '$lib/settings.js'
 
   export let data
 
@@ -74,6 +75,10 @@
         </div>
       {/if}
       {#each data.posts.posts as post, index (post.post.id)}
+        {#if
+          !($userSettings.hidePosts.deleted && post.post.deleted) &&
+          !($userSettings.hidePosts.removed && post.post.removed)
+        }
         <div
           in:fly={{
             y: -8,
@@ -84,6 +89,7 @@
         >
           <Post {post} />
         </div>
+        {/if}
       {/each}
     </section>
     <Pageination

--- a/src/routes/c/[name]/+page.svelte
+++ b/src/routes/c/[name]/+page.svelte
@@ -66,9 +66,14 @@
       <Sort selected={data.sort} />
     </div>
     {#each data.posts.posts as post, index (post.post.id)}
+      {#if
+        !($userSettings.hidePosts.deleted && post.post.deleted) &&
+        !($userSettings.hidePosts.removed && post.post.removed)
+      }
       <div in:fly={{ y: -8, opacity: 0, delay: index < 4 ? index * 100 : 0 }}>
         <Post hideCommunity={true} {post} />
       </div>
+      {/if}
     {/each}
     <Pageination
       page={data.page}

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -64,6 +64,20 @@
     </span>
     <Switch bind:enabled={$userSettings.showCompactPosts} />
   </Setting>
+  <Setting>
+    <span slot="title">Hide Posts</span>
+    <span slot="description">Hide certain types of posts.</span>
+    <div class="flex flex-row items-center gap-4">
+      <div class="flex items-center gap-1 font-bold">
+        Deleted Posts
+        <Switch bind:enabled={$userSettings.hidePosts.deleted} />
+      </div>
+      <div class="flex items-center gap-1 font-bold">
+        Removed Posts
+        <Switch bind:enabled={$userSettings.hidePosts.removed} />
+      </div>
+    </div>
+  </Setting>
   <h2 class="uppercase font-bold opacity-80 text-sm mt-4">Instances</h2>
   <Setting>
     <span slot="title">Show instances</span>


### PR DESCRIPTION
Add hidePosts.{deleted,removed} settings to control whether or not to display posts that have been marked as deleted or removed.  By default, these are enabled (ie. hidden) to correspond to Lemmy-UI behavior.

Currently, this change only hides these posts for the front page and community pages.

Before these settings are introduced, you can see all posts regardless of if they are deleted or removed:

![Screenshot from 2023-08-05 13-58-31](https://github.com/Xyphyn/photon/assets/3976244/f750d44f-459f-4be1-b9ec-aaf99d8d9a42)

After these changes, you can hide both removed and deleted:

![Screenshot from 2023-08-05 14-32-31](https://github.com/Xyphyn/photon/assets/3976244/713397d6-2e65-4678-b77f-9a0d35c28e58)

Or just hide deleted:

![Screenshot from 2023-08-05 14-33-03](https://github.com/Xyphyn/photon/assets/3976244/11d6ec31-bf60-4f95-8eed-0ec376b518c9)

Or just hide the removed:

![Screenshot from 2023-08-05 14-32-47](https://github.com/Xyphyn/photon/assets/3976244/95ee6481-13e7-4ee9-ba67-63bcc5fdcab2)
