### PR TITLE
misc: allow community card to be full width and remove left border

### DIFF
--- a/src/lib/components/ui/StickyCard.svelte
+++ b/src/lib/components/ui/StickyCard.svelte
@@ -1,7 +1,7 @@
 <aside
   class="sticky top-16 break-words flex
-    flex-col gap-4 p-6 max-w-[20rem] min-w-[18rem] max-h-[calc(100svh-4rem)]
-    overflow-auto text-sm border-l border-slate-200 dark:border-zinc-800 {$$props.class}"
+    flex-col gap-4 p-6 max-w-[32rem] min-w-[18rem] max-h-[calc(100svh-4rem)]
+    overflow-auto text-sm border-slate-200 dark:border-zinc-800 {$$props.class}"
 >
   <slot />
 </aside>


### PR DESCRIPTION
Right now, the community card model displays the information in a very narrow column with a lot of extra whitespace on the side and a weird left border.  Likewise, user pages also include a left border if the StickyCard is placed at the top.

This removes the left border completely, and allows the StickyCard to be wider in order to allow for more information to be displayed.

Here is what a community sidebar looks like now:

![Screenshot from 2023-08-05 21-33-38](https://github.com/Xyphyn/photon/assets/3976244/00e19ec4-9770-43a7-ab5f-c720d8c8851d)

After this change, the sidebar is wider and has no left border:

![Screenshot from 2023-08-05 21-34-01](https://github.com/Xyphyn/photon/assets/3976244/0f486365-4f54-40ef-879e-0cd0d979d500)

User profiles exhibit the same change at full screen.

Here is what the community modal looks like now:

![Screenshot from 2023-08-05 21-34-54](https://github.com/Xyphyn/photon/assets/3976244/f113a35b-a54a-45d4-b806-eae3261bcba4)

As you can see, it is narrow and has a left border.  After this change, this is what the community modal looks like:

![Screenshot from 2023-08-05 21-35-06](https://github.com/Xyphyn/photon/assets/3976244/14a7e7f6-032f-4c9e-a102-b4eec5897029)

Likewise, here is what a user profile looks like if there is no sidebar:

![Screenshot from 2023-08-05 21-35-17](https://github.com/Xyphyn/photon/assets/3976244/e85da40c-418b-4518-b5b2-2497d2700e6f)

Again, there is a left border that is not necessary. After this change, there is no left border:

![Screenshot from 2023-08-05 21-35-21](https://github.com/Xyphyn/photon/assets/3976244/d03604f4-d60c-4ca3-b12c-cd687c36a82e)



