### PR TITLE
Fixed incorrect env var name for showing instances for comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The following environment variables can be set to override the default settings:
 | PUBLIC_REVERT_VOTE_COLORS       | `bool`              | false         |
 | PUBLIC_SHOW_INSTANCES_USER      | `bool`              | false         |
 | PUBLIC_SHOW_INSTANCES_COMMUNITY | `bool`              | true          |
-| PUBLIC_SHOW_INSTANCES_COMMENT   | `bool`              | false         |
+| PUBLIC_SHOW_INSTANCES_COMMENTS  | `bool`              | false         |
 | PUBLIC_SHOW_COMPACT_POSTS       | `bool`              | false         |
 | PUBLIC_DEFAULT_FEED_SORT        | `SortType`          | Active        |
 | PUBLIC_DEFAULT_FEED             | `ListingType`       | Local         |


### PR DESCRIPTION
Just noticed I had a typo in README.md with the wrong env var name for PUBLIC_SHOW_INSTANCES_COMMENTS.  I accidentally left off the "S" at the end.