### PR TITLE
Allow instance admins access to the "Moderation" menu for federated posts/comments

### DIFF
--- a/src/lib/components/lemmy/moderation/CommentModerationMenu.svelte
+++ b/src/lib/components/lemmy/moderation/CommentModerationMenu.svelte
@@ -32,7 +32,7 @@
   </Button>
   {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user))}
     <li class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-      Moderation
+      Moderation {#if (!item.community.local) } (Instance Only) {/if}
     </li>
     <MenuButton color="success" on:click={() => remove(item)}>
       <Icon src={Trash} size="16" mini />
@@ -44,7 +44,7 @@
     </MenuButton>
     {#if $profile?.user && $profile.user?.local_user_view.person.id != item.creator.id}
       <span class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-        User
+        User {#if (!item.community.local) } (Instance Only) {/if}
       </span>
       <MenuButton
         color="dangerSecondary"

--- a/src/lib/components/lemmy/moderation/CommentModerationMenu.svelte
+++ b/src/lib/components/lemmy/moderation/CommentModerationMenu.svelte
@@ -30,7 +30,7 @@
   >
     <ShieldIcon filled width={14} />
   </Button>
-  {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user) && item.community.local)}
+  {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user))}
     <li class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
       Moderation
     </li>

--- a/src/lib/components/lemmy/moderation/ModerationMenu.svelte
+++ b/src/lib/components/lemmy/moderation/ModerationMenu.svelte
@@ -112,7 +112,7 @@
       />
     </svg>
   </Button>
-  {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user) && item.community.local)}
+  {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user))}
     <span class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
       Moderation
     </span>

--- a/src/lib/components/lemmy/moderation/ModerationMenu.svelte
+++ b/src/lib/components/lemmy/moderation/ModerationMenu.svelte
@@ -114,7 +114,7 @@
   </Button>
   {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user))}
     <span class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-      Moderation
+        Moderation {#if (!item.community.local) } (Instance Only) {/if}
     </span>
     <MenuButton
       color="warning"
@@ -156,7 +156,7 @@
     </MenuButton>
     {#if $profile?.user && $profile.user.local_user_view.person.id != item.creator.id}
       <span class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-        User
+        User {#if (!item.community.local) } (Instance Only) {/if}
       </span>
       <MenuButton
         color="dangerSecondary"


### PR DESCRIPTION
This PR removes the check for whether a community is local before showing moderation options to instance admins.

## Purpose/Rationale

In the main Lemmy UI, instance admins have full moderation control over remote content as far as their instance is concerned.  They can lock, unlock, remove content, community-ban a user, and pin posts to their local copy of the community.  While these only affect the local instance, they are important moderation abilities.

This allows instance admins to respond to reports from users of their instance when the reported content is from a federated instance (spam, NSFW, local instance rule violation, etc).  This is especially helpful when the remote admin/moderator is slow to respond to reports or if the content violates a local server rule but doesn't violate a rule on the originating instance.  Again, the main Lemmy UI and API support this, so it would only be bringing Photon further to feature parity.

Currently, only Purge is shown for instance admins when the content is on a remote instance.  The problem with "Purge" is that it does exactly what it says: purges the item from the database completely and forgets it ever saw it.

If someone on a federated instance, which still sees the content, votes or comments on it, it will re-sync to the local instance and re-appear in the feed/post.  "Remove", which is only a moderation action, will prevent the content from re-syncing.

I am running this change on my customized build and have tested as such:

### Tests Performed
1. The project successfully builds with this change.
2. Admin user does have moderation options enabled and all work (haven't tested 'Ban from Community' but if it's just calling the API and works already for moderators, then it should work for an admin as well since the API allows that).
3. Logging in as a moderator user has no additional options shown in mod menu nor do they see a moderator button where they shouldn't.
4. Logged-out and unprivileged users see no moderator button at all.

Thoughts?
