### PR TITLE
Update Mod Menus to account for federated moderators - Hide 'reply with reason' if mod action is instance-only.

### DIFF
--- a/src/lib/components/lemmy/moderation/CommentModerationMenu.svelte
+++ b/src/lib/components/lemmy/moderation/CommentModerationMenu.svelte
@@ -32,7 +32,7 @@
   </Button>
   {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user))}
     <li class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-      Moderation {#if (!item.community.local) } (Instance Only) {/if}
+      Moderation {#if (!item.community.local && !amMod($profile.user, item.community)) } (Instance Only) {/if}
     </li>
     <MenuButton color="success" on:click={() => remove(item)}>
       <Icon src={Trash} size="16" mini />
@@ -44,7 +44,7 @@
     </MenuButton>
     {#if $profile?.user && $profile.user?.local_user_view.person.id != item.creator.id}
       <span class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-        User {#if (!item.community.local) } (Instance Only) {/if}
+        User {#if (!item.community.local && !amMod($profile.user, item.community)) } (Instance Only) {/if}
       </span>
       <MenuButton
         color="dangerSecondary"

--- a/src/lib/components/lemmy/moderation/ModerationMenu.svelte
+++ b/src/lib/components/lemmy/moderation/ModerationMenu.svelte
@@ -115,7 +115,7 @@
   </Button>
   {#if ($profile?.user && amMod($profile.user, item.community)) || ($profile?.user && isAdmin($profile.user))}
     <span class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-      Moderation {#if !item.community.local} (Instance Only) {/if}
+      Moderation {#if !item.community.local && !amMod($profile.user, item.community)} (Instance Only) {/if}
     </span>
     <MenuButton
       color="warning"
@@ -159,7 +159,7 @@
     </MenuButton>
     {#if $profile?.user && $profile.user.local_user_view.person.id != item.creator.id}
       <span class="px-4 py-1 my-1 text-xs text-slate-600 dark:text-zinc-400">
-        User {#if !item.community.local} (Instance Only) {/if}
+        User {#if !item.community.local && !amMod($profile.user, item.community)} (Instance Only) {/if}
       </span>
       <MenuButton
         color="dangerSecondary"

--- a/src/lib/components/lemmy/moderation/RemoveModal.svelte
+++ b/src/lib/components/lemmy/moderation/RemoveModal.svelte
@@ -16,6 +16,7 @@
   import { removalTemplate } from '$lib/components/lemmy/moderation/moderation.js'
   import { userSettings } from '$lib/settings.js'
   import { fullCommunityName } from '$lib/util.js'
+  import { amMod, isAdmin } from './moderation'
 
   export let open: boolean
   export let item: PostView | CommentView | undefined = undefined
@@ -201,7 +202,7 @@
         bind:value={reason}
       />
 
-      {#if !removed}
+      {#if !removed && ( amMod($profile.user, item.community) || (isAdmin($profile.user) && item.community.local))}
         <Checkbox bind:checked={commentReason}>Reply with reason</Checkbox>
 
         {#if commentReason}


### PR DESCRIPTION
Enhancement to the last [pull request](https://github.com/Xyphyn/photon/pull/122) with the following changes to better account for federated moderation:

### Purpose/Rationale
It doesn't make sense to "Reply with reason" when removing a federated post/comment only on your instance (reported by Cole in the Matrix/Discord chat).  This PR updates `RemoveModal.svelte` to check whether you are a mod of the remote community or if the content is local to the instance to conditionally hide the "Reply with reason" options.

Additionally, the last PR (122) did not account for cross-instance community moderators before adding "(Instance Only)" to the Moderation and User headings in the moderation menus.  This covers the case where you are a local admin and also a moderator of a remote community so that it correctly indicates the mod action will be federated.


### Changes
#### ModerationMenu.svelte  and CommentModerationMenu.svelte
- Only shows the  "(Instance only)"  text if the community is remote AND the user is not a moderator of the remote community.

#### RemoveModal.svelte
- Hides the "Reply with reason" checkbox and field if the removal is only for the local instance.
- Still shows the "reply with reason" checkbox if the content is remote but the instance admin is also a moderator of that federated community.

### Tests Perfomed
I'm running with these changes on my instance and have tested as follows:

- Photon successfully builds with these changes
- The "remove content" modal hides the "reply with reason" checkbox and text field when removing content that is not local to my instance and for a community where my local admin account is _not_ a moderator.
- The "remove content" modal shows the "reply with reason" checkbox and text field when removing content that is local to my instance.
-  The "remove content" modal shows the "reply with reason" checkbox and text field when removing federated content and my local admin account is also a moderator of the remote community.
- The "Moderation" and "User" headings in the post and comment moderation menus now correctly show (Instance Only) only if my local admin account is not a moderator of the remote community.
-  The"Moderation" and "User" headings in the post and comment moderation menus correctly show (Instance Only) if my admin account is NOT a moderator of a remote community.