### PR TITLE
Add ⌘+<shortcut> support

### DIFF
--- a/src/lib/components/markdown/MarkdownEditor.svelte
+++ b/src/lib/components/markdown/MarkdownEditor.svelte
@@ -233,7 +233,7 @@ overflow-hidden focus-within:border-black focus-within:dark:border-white transit
         bind:item={textArea}
         on:keydown={(e) => {
           if (disabled) return
-          if (e.ctrlKey) {
+          if (e.ctrlKey || e.metaKey) {
             // @ts-ignore
             let shortcut = shortcuts[e.code]
             if (shortcut) {


### PR DESCRIPTION
Macs use metaKey, which is bound on a mac keyboard as ⌘ for the majority of their shortcuts. This adds support for that OR control
