### PR TITLE
Add max-width to markdown paragraphs

### DIFF
--- a/src/lib/components/markdown/Markdown.svelte
+++ b/src/lib/components/markdown/Markdown.svelte
@@ -87,6 +87,6 @@
   }
 
   .markdown :global(p) {
-    @apply leading-[1.5];
+    @apply leading-[1.5] max-w-3xl;
   }
 </style>


### PR DESCRIPTION
Adding a max width to markdown paragraphs improves readability on large screens, as it prevents long runs of text from taking the full width of the browser window.

Before:

![CleanShot 2023-08-30 at 14 31 13@2x](https://github.com/Xyphyn/photon/assets/168193/da1a82ee-0795-4249-a74f-46546ba86160)

After:

![CleanShot 2023-08-30 at 14 32 30@2x](https://github.com/Xyphyn/photon/assets/168193/51e67128-340c-499f-b243-129995aa7559)

