### PR TITLE
Center images in card view

### DIFF
--- a/src/lib/components/lemmy/post/Post.svelte
+++ b/src/lib/components/lemmy/post/Post.svelte
@@ -72,17 +72,17 @@
           <svelte:component
             this={$userSettings.expandImages ? ExpandableImage : Empty}
             url={bestImageURL(post.post, false, 2048)}
-            class="self-start max-w-full"
+            class="self-stretch max-w-full"
           >
             <svelte:element
               this={$userSettings.expandImages ? 'div' : 'a'}
               href={postLink(post.post)}
-              class="self-start overflow-hidden z-10 relative bg-slate-200 dark:bg-zinc-800 rounded-md max-w-full"
+              class="self-stretch overflow-hidden z-10 relative bg-slate-200 dark:bg-zinc-800 rounded-md max-w-full"
               data-sveltekit-preload-data="off"
               aria-label={post.post.name}
             >
               <picture
-                class="rounded-md overflow-hidden max-h-[min(50vh,500px)] w-full max-w-full"
+                class="flex justify-center rounded-md overflow-hidden max-h-[min(min-content, 50vh,500px)] w-full max-w-full"
               >
                 <source
                   srcset={bestImageURL(post.post, false, 512)}

--- a/src/lib/components/ui/ExpandableImage.svelte
+++ b/src/lib/components/ui/ExpandableImage.svelte
@@ -47,6 +47,6 @@
   </div>
 {/if}
 
-<button on:click={() => (open = !open)} class="w-max {$$props.class}">
+<button on:click={() => (open = !open)} class="{$$props.class}">
   <slot />
 </button>


### PR DESCRIPTION
This PR attempts to center the images in the card view, which (IMO) looks better.

Before:
![image](https://github.com/Xyphyn/photon/assets/34815293/a5d8a595-3da6-468a-9ef5-73824f7a0926)

After:
![image](https://github.com/Xyphyn/photon/assets/34815293/431aeb60-d10a-4960-9fb6-a94e69aa4dfa)
