### PR TITLE
Fix ExpandableImage overlap with header

### DIFF
--- a/src/lib/components/ui/ExpandableImage.svelte
+++ b/src/lib/components/ui/ExpandableImage.svelte
@@ -1,20 +1,29 @@
 <script lang="ts">
-  import { Button } from 'mono-svelte'
-  import { Icon, XMark } from 'svelte-hero-icons'
-  import { expoOut } from 'svelte/easing'
-  import { fade, scale } from 'svelte/transition'
+  import { Button } from "mono-svelte";
+  import { Icon, XMark } from "svelte-hero-icons";
+  import { expoOut } from "svelte/easing";
+  import { fade, scale } from "svelte/transition";
 
   /**
    * The full-resolution image URL
    */
-  export let url: string
-  export let alt: string = ''
-  export let open: boolean = false
+  export let url: string;
+  export let alt: string = "";
+  export let open: boolean = false;
+
+  let bodyOverflowOld: string;
+
+  $: if (open) {
+    bodyOverflowOld = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+  } else {
+    document.body.style.overflow = bodyOverflowOld;
+  }
 </script>
 
 <svelte:body
   on:keydown={(e) => {
-    if (open && e.code == 'Escape') open = false
+    if (open && e.code == "Escape") open = false;
   }}
 />
 
@@ -24,8 +33,8 @@
   <!-- svelte-ignore a11y-click-events-have-key-events -->
   <!-- svelte-ignore a11y-positive-tabindex -->
   <div
-    class="fixed top-0 left-0 w-screen h-screen overflow-auto bg-black/50
-    flex flex-col z-[200] overscroll-contain"
+    class="fixed top-16 left-0 w-screen h-[calc(100vh-theme(spacing.16))] overflow-auto bg-black/50
+    flex flex-col z-[200] overscroll-contain py-8"
     transition:fade={{ duration: 200 }}
     on:click={() => (open = false)}
   >
@@ -40,7 +49,7 @@
       width={400}
       height={400}
       src={url}
-      class="w-full h-auto object-contain max-w-screen-sm mx-auto my-auto overscroll-contain bg-white dark:bg-zinc-900"
+      class="w-max max-h-full object-contain max-w-screen-sm mx-auto my-auto overscroll-contain bg-white dark:bg-zinc-900"
       transition:scale={{ start: 0.9, easing: expoOut }}
       {alt}
     />


### PR DESCRIPTION
This PR attempts to fix the expanding image being shown behind the navbar header.

Before:
![image](https://github.com/Xyphyn/photon/assets/34815293/16764107-214b-4c3f-a533-f94ec0986299)

After:
![image](https://github.com/Xyphyn/photon/assets/34815293/a2363eb7-8979-4ed3-9ab1-71a616c98a01)

I am new to svelte and web development in general so please let me know if you don't like this fix or have any suggestions :)