### PR TITLE
Show "hidden" for missing mod names in modlog

### DIFF
--- a/src/routes/modlog/item/ModlogItemTable.svelte
+++ b/src/routes/modlog/item/ModlogItemTable.svelte
@@ -23,6 +23,8 @@
         avatarSize={20}
         user={item.moderator}
       />
+    {:else}
+      <p class="text-slate-500 dark:text-zinc-500">Hidden<p/>
     {/if}
   </td>
   <td>


### PR DESCRIPTION
Show "Hidden" instead of leaving the mod name empty.

I think if the backend does not return the mod name, that means that they set it to be hidden so imo it's nice to explicitly show that to the user.