### PR TITLE
Remove misplaced single quotation marks to avoid showing an undefined thumbnail in card view

### DIFF
--- a/src/lib/components/lemmy/post/Post.svelte
+++ b/src/lib/components/lemmy/post/Post.svelte
@@ -137,7 +137,7 @@
         <PostLink
           url={post.post.url}
           thumbnail_url={view == 'card'
-            ? 'post.post.thumbnail_url'
+            ? post.post.thumbnail_url
               ? `${post.post.thumbnail_url}?format=webp&thumbnail=512`
               : undefined
             : undefined}


### PR DESCRIPTION
I noticed that some posts in card view were showing a blank thumbnail, and in those cases the thumbnail URL was `undefined?format=webp&thumbnail=512`. This happens because the variable `post.post.thumbnail_url` was inside single quotation marks, so it was being interpreted as the literal string `post.post.thumbnail_url` instead of that variable's value, and so the thumbnail was being shown even if the variable was undefined.