### PR TITLE
Add timestamp to registration applications

### DIFF
--- a/src/routes/admin/applications/Application.svelte
+++ b/src/routes/admin/applications/Application.svelte
@@ -51,7 +51,10 @@
 
 <Material class="flex flex-col gap-2">
   <div class="flex flex-col gap-1">
+    <span class="text-slate-600 dark:text-zinc-400">
     <RelativeDate date={publishedToDate(application.registration_application.published)} />
+    </span>
+
     <SectionTitle>User</SectionTitle>
     <span class="text-sm">
       <UserLink user={application.creator} avatar avatarSize={20} />

--- a/src/routes/admin/applications/Application.svelte
+++ b/src/routes/admin/applications/Application.svelte
@@ -7,6 +7,8 @@
   import type { RegistrationApplicationView } from 'lemmy-js-client'
   import { Button } from 'mono-svelte'
   import { Check, Icon, XMark } from 'svelte-hero-icons'
+  import RelativeDate from '$lib/components/util/RelativeDate.svelte';
+  import { publishedToDate } from '$lib/components/util/date';
 
   export let application: RegistrationApplicationView
 
@@ -49,6 +51,7 @@
 
 <Material class="flex flex-col gap-2">
   <div class="flex flex-col gap-1">
+    <RelativeDate date={publishedToDate(application.registration_application.published)} />
     <SectionTitle>User</SectionTitle>
     <span class="text-sm">
       <UserLink user={application.creator} avatar avatarSize={20} />


### PR DESCRIPTION
As an instance admin, this info is nice to have, and I sometimes open the official UI just to see it.

The placement is naturally up for debate, I'm unsure where it fits best.

In the (near) future, I'd also like to add a notification dot similar to inbox unreads, but for applications instead.