### PR TITLE
Simplify login screen

### DIFF
--- a/src/lib/lemmy.ts
+++ b/src/lib/lemmy.ts
@@ -99,3 +99,28 @@ export async function validateInstance(instance: string): Promise<boolean> {
     return false
   }
 }
+
+export function mayBeIncompatible(minVersion: string, availableVersion: string) {
+  if (minVersion.valueOf() === availableVersion.valueOf()) return false;
+
+  const versionFormatter = /[\d.]/;
+  if (!minVersion.match(versionFormatter) || !availableVersion.match(availableVersion)) {
+    return true;
+  }
+
+  const splitMinVersion = minVersion.split('.');
+  const splitAvailableVersion = availableVersion.split('.');
+
+  if (splitMinVersion.length !== splitAvailableVersion.length) return true;
+
+  for (let i = 0; i < splitMinVersion.length; ++i) {
+    const minVersionDigit = parseInt(splitMinVersion[i]);
+    const availableVersionDigit = parseInt(splitAvailableVersion[i]);
+
+    if (availableVersionDigit === undefined) return true;
+    if (minVersionDigit < availableVersionDigit) return false;
+    if (availableVersionDigit < minVersionDigit) return true;
+  }
+
+  return false;
+}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -3,10 +3,9 @@
   import { setUser } from '$lib/auth.js'
   import { Note, toast } from 'mono-svelte'
   import { DEFAULT_INSTANCE_URL, LINKED_INSTANCE_URL } from '$lib/instance.js'
-  import { getClient, validateInstance } from '$lib/lemmy.js'
+  import { getClient, mayBeIncompatible, site, validateInstance } from '$lib/lemmy.js'
   import { Button, TextInput } from 'mono-svelte'
   import {
-    AtSymbol,
     Icon,
     Identification,
     QuestionMarkCircle,
@@ -65,21 +64,21 @@
   <form on:submit|preventDefault={logIn} class="flex flex-col gap-5">
     <div class="flex flex-col gap-2">
       <h1 class="font-bold text-3xl">Log In</h1>
-      <p>Enter the fediverse</p>
-      <Note>
-        This version of Photon supports instances running
-        <span style="font-family: monospace;">
-          v{MINIMUM_VERSION}
-        </span>
-        or higher.
-      </Note>
+      {#if $site && mayBeIncompatible(MINIMUM_VERSION, $site.version.replace("v", ""))}
+        <Note>
+          This version of Photon supports instances running
+          <span style="font-family: monospace;">
+            v{MINIMUM_VERSION}
+          </span>
+          or higher.
+        </Note>
+      {/if}
     </div>
     <div class="flex flex-row w-full items-center gap-2">
       <TextInput
         id="username"
         bind:value={data.username}
         label="Username"
-        placeholder="Example"
         class="flex-1"
         required
       />


### PR DESCRIPTION
Some minor UX suggestions, following the 'less is more' motto.

Before:

![Screen Shot 2023-10-15 at 23 38 52](https://github.com/Xyphyn/photon/assets/1407980/87970a77-084c-40b3-ac5e-ed0b52a24bd5)

After:

![Screen Shot 2023-10-15 at 23 39 00](https://github.com/Xyphyn/photon/assets/1407980/2d7baaa0-7fae-49aa-91b3-3350663196a8)

- Only warn about the minimum instance version if there may be a compatibility issue
- Remove username placeholder because it's not communicating new information
- Remove subtitle to improve signal-to-noise ratio

I'm also playing with the idea of hiding the 2FA code field unless the Lemmy server signals that the account is protected with 2FA, but I've kept that out of scope for now.