### PR TITLE
A few UX tweaks

### DIFF
--- a/src/lib/components/ui/sidebar/Sidebar.svelte
+++ b/src/lib/components/ui/sidebar/Sidebar.svelte
@@ -18,7 +18,7 @@
   import { flip } from 'svelte/animate'
   import { expoOut } from 'svelte/easing'
   import { Button } from 'mono-svelte'
-  import { DEFAULT_INSTANCE_URL } from '$lib/instance.js'
+  import { DEFAULT_INSTANCE_URL, LINKED_INSTANCE_URL } from '$lib/instance.js'
 
   export let route = ''
 </script>
@@ -91,9 +91,11 @@
       <Icon mini src={Identification} size="20" />
       <span slot="label">Sign Up</span>
     </SidebarButton>
-    <SidebarButton href="/accounts" title="Change Instance">
-      <Icon mini src={ServerStack} size="20" />
-      <span slot="label">Change instance</span>
-    </SidebarButton>
+    {#if LINKED_INSTANCE_URL === undefined}
+      <SidebarButton href="/accounts" title="Change Instance">
+        <Icon mini src={ServerStack} size="20" />
+        <span slot="label">Change instance</span>
+      </SidebarButton>
+    {/if}
   {/if}
 </nav>

--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -158,24 +158,25 @@
           Sign up
         </Button>
       </div>
-      <div class="flex flex-row font-normal gap-2">
-        <TextInput
-          label="Guest instance"
-          on:change={changeGuestInstance}
-          placeholder="Instance URL"
-          bind:value={newInstance}
-          disabled={LINKED_INSTANCE_URL != undefined}
-        />
-        <Button
-          color="primary"
-          class="h-max self-end"
-          size="lg"
-          {loading}
-          disabled={loading || LINKED_INSTANCE_URL != undefined}
-        >
-          Change
-        </Button>
-      </div>
+      {#if LINKED_INSTANCE_URL === undefined}
+        <div class="flex flex-row font-normal gap-2">
+          <TextInput
+            label="Guest instance"
+            on:change={changeGuestInstance}
+            placeholder="Instance URL"
+            bind:value={newInstance}
+          />
+          <Button
+            color="primary"
+            class="h-max self-end"
+            size="lg"
+            {loading}
+            disabled={loading}
+          >
+            Change
+          </Button>
+        </div>
+      {/if}
     </div>
   </div>
 {:else}


### PR DESCRIPTION
### Hide instance switcher when locked to instance
In the use case of https://photon.lemmy.world/, it might not make a lot of sense to display this:

![image](https://github.com/Xyphyn/photon/assets/1407980/8534e9f7-590f-45bf-9f26-592b5601abb3)

### Don't show 'Change instance' when locked to instance

I've hidden this sidebar link:

![image](https://github.com/Xyphyn/photon/assets/1407980/869f22f7-b941-465a-a9c3-94feac8fa57c)

### Show communities when logged out

Hopefully this'll encourage anonymous visitors to explore and get involved.

![image](https://github.com/Xyphyn/photon/assets/1407980/7fe03f40-a752-4947-8bc3-1effd50f4da6)

