### PR TITLE
Make it easier to skim through posts

### DIFF
--- a/src/lib/components/lemmy/post/Post.svelte
+++ b/src/lib/components/lemmy/post/Post.svelte
@@ -65,7 +65,7 @@
           <a
             target={$userSettings.openLinksInNewTab ? '_blank' : ''}
             href="/post/{getInstance()}/{post.post.id}"
-            class="font-medium max-w-full w-full break-words text-base"
+            class="font-medium max-w-full w-full break-words text-lg"
             style="word-break: break-word;"
             class:text-slate-500={post.read && $userSettings.markReadPosts}
             class:dark:text-zinc-400={post.read && $userSettings.markReadPosts}

--- a/src/routes/post/[instance]/[id=integer]/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/+page.svelte
@@ -177,7 +177,7 @@
       <Icon src={ArrowLeft} mini size="16" slot="prefix" />
     </Button>
   </div>
-  <h1 class="font-bold text-lg">
+  <h1 class="font-bold text-xl">
     <Markdown source={post.post_view.post.name} inline />
   </h1>
   <PostMedia


### PR DESCRIPTION
When scrolling through the frontpage, post titles are often very small compared to image content. Assuming the user is initially most interested in the title, making titles a bit more prominent helps when skimming:

![Screenshot 2023-10-18 at 20-22-04 Photon](https://github.com/Xyphyn/photon/assets/1407980/1b987d92-4a63-4cb4-bacf-8c9342d73845)

This works pretty well for text posts. The modest font increase establishes a clearer visual hierarchy between title and content:

![image](https://github.com/Xyphyn/photon/assets/1407980/b075e3b6-3cef-403e-95bb-cd82403e6e2d)

I've also updated the post detail page for consistency.