### PR TITLE
Add Deny Reason to Application Route

### DIFF
--- a/src/routes/admin/applications/Application.svelte
+++ b/src/routes/admin/applications/Application.svelte
@@ -88,7 +88,7 @@
           ? '!text-red-500'
           : ''}"
         aria-label="Deny"
-        on:click={() => review(false)}
+        on:click={() => review(false)/* Instead of finishing the review add a Textbox and transform the X into a "Deny"*/}
         loading={denying}
         disabled={approving || denying}
       >


### PR DESCRIPTION
WIP Pull Request, no idea how long this will take.

Current Plan is to:
- Merge the Tick and Cross Buttons into a single "Deny" button, maybe even with an Animation
- Add a Textbox for a Deny reason to the left of the new "Deny" button
- Display deny reasons next to the "Denied by XY" Text in the Style: "Denied by XY: 'Deny Reason'"

@Xyphyn before I start working on it do the planned changes sound acceptable?