### PR TITLE
Only show lemmy servers in instance autocomplete

### DIFF
--- a/src/lib/components/lemmy/ObjectAutocomplete.svelte
+++ b/src/lib/components/lemmy/ObjectAutocomplete.svelte
@@ -70,7 +70,7 @@
       const results = await instances || {}
 
       return q ? (results.federated_instances?.linked || []).filter(
-        (i) => i.domain.includes(q)
+        (i) => i.software === 'lemmy' && i.domain.includes(q)
       ) : []
     }}
     extractName={(i) => `${i.domain}`}


### PR DESCRIPTION
Quick fix for #201 

Only shows lemmy instances in the instance autocomplete. Seems easier than letting it fail and showing a user friendly error message, since there are a LOT of non-Lemmy peers in most instances' federation lists.