### PR TITLE
BugFix: Deny Reason does not get cleared

### DIFF
--- a/src/routes/admin/applications/Application.svelte
+++ b/src/routes/admin/applications/Application.svelte
@@ -33,7 +33,10 @@
       while (reviewing) {
         await new Promise(res => setTimeout(res, 1000))
       }
-      if (!denying) return
+      if (!denying) {
+        denyReason = ""
+        return
+      }
       if (denyReason != "") {
         registrationApplicationAnswer.deny_reason = denyReason
       }


### PR DESCRIPTION
Steps to reproduce Bug:
- Start Denial Process
- Enter any deny reason
- cancel Denial
- approve request instead

Result: Approved Application has displayed deny reason.

This fixes that by clearing the denyReason var before cancelling out of the review function