### PR TITLE
Fix community autocomplete on search page

### DIFF
--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -41,7 +41,7 @@
 
   let pageNum = data.page
 
-  let moreOptions = false
+  let moreOptions = !!$page.url.searchParams.get('community')
 </script>
 
 <svelte:head>
@@ -101,6 +101,9 @@
       jwt={$profile?.jwt}
       listing_type={'All'}
       showWhenEmpty={true}
+      q={$page.url.searchParams.get('community')
+        ? data.filters?.community ?? 'Selected'
+        : ''}
       on:select={(c) =>
         searchParam($page.url, 'community', c.detail?.id || undefined, 'page')}
     />

--- a/src/routes/search/+page.ts
+++ b/src/routes/search/+page.ts
@@ -42,12 +42,17 @@ export async function load({ url, fetch }) {
         Date.parse(getItemPublished(b)) - Date.parse(getItemPublished(a))
     )
 
+    const communityName = (posts[0] || comments[0] || communities[0]).community.title
+
     return {
       type: type,
       sort: sort,
       page: page,
       query: query,
       results: everything,
+      filters: {
+        community: community ? communityName : undefined,
+      },
       streamed: {
         object: get(profile)?.jwt
           ? getClient(undefined, fetch).resolveObject({


### PR DESCRIPTION
This makes the community autocomplete on the search page show either "Selected" when a community filter has been used, or the name of the community, if possible.

Works analogous to recent similar changes made on the modlog page.

This fixes #216.