### PR TITLE
Disable commenting if banned from community

### DIFF
--- a/src/lib/components/lemmy/comment/CommentActions.svelte
+++ b/src/lib/components/lemmy/comment/CommentActions.svelte
@@ -54,7 +54,7 @@
     color="tertiary"
     class="text-slate-600 dark:text-zinc-400"
     on:click={() => (replying = !replying)}
-    disabled={comment.post.locked}
+    disabled={comment.post.locked || comment.banned_from_community}
   >
     <Icon src={ArrowUturnLeft} width={14} height={14} mini />
     <span class="text-xs">{$t('comment.reply')}</span>

--- a/src/lib/components/lemmy/comment/CommentForm.svelte
+++ b/src/lib/components/lemmy/comment/CommentForm.svelte
@@ -12,6 +12,7 @@
 
   export let postId: number
   export let parentId: number | undefined = undefined
+  export let banned: boolean = false
   export let locked: boolean = false
   export let rows: number = 7
   export let placeholder: string | undefined = undefined
@@ -67,9 +68,10 @@
       {rows}
       placeholder={locked
         ? $t('comment.locked')
+        : banned ? $t('comment.banned')
         : placeholder ?? placeholders.get('comment')}
       bind:value
-      disabled={locked || loading}
+      disabled={banned || locked || loading}
       on:confirm={() => {
         if (actions) {
           submit()
@@ -87,7 +89,7 @@
             size="lg"
             class="sm:ml-auto w-28"
             {loading}
-            disabled={locked || loading}
+            disabled={banned || locked || loading}
           >
             {$t('form.submit')}
           </Button>

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -416,6 +416,7 @@
       "link": "Copy Link"
     },
     "locked": "This post is locked.",
+    "banned": "You have been banned from this community.",
     "more": "{{comments:number}} more"
   },
   "moderation": {

--- a/src/routes/post/[instance]/[id=integer]/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/+page.svelte
@@ -310,6 +310,7 @@ flex-wrap gap-4 sticky top-20 w-full box-border z-20 mt-4"
           comment.detail.comment_view,
           ...data.comments.comments,
         ])}
+      banned={post.post_view.banned_from_community}
       locked={post.post_view.post.locked ||
         $page.params.instance.toLowerCase() != $instance.toLowerCase()}
       on:focus={() => (commenting = true)}


### PR DESCRIPTION
This makes the comments section behave the same as for locked posts, if the user has been banned.

If banned:
- Disable comment markdown editor
  - Display ban message 
- Disable comment submit button
- Disable comment reply button

<details>
<summary>Screenshots</summary>

![image](https://github.com/Xyphyn/photon/assets/100710152/e6d78fe7-d326-4064-b1fe-ec04c462f70a)
![image](https://github.com/Xyphyn/photon/assets/100710152/754ff526-5ad7-45d8-8c11-a25c00cd4bb2)

</details>

Related issue: #318 
This fixes the immediate complaint, but there's more to do, so I wouldn't close it yet. I'll try to break the rest of this issue into small, clearly defined tasks later.