### PR TITLE
Added home, settings and explore menu entries back into sidebar

### DIFF
--- a/src/lib/components/ui/sidebar/Sidebar.svelte
+++ b/src/lib/components/ui/sidebar/Sidebar.svelte
@@ -35,6 +35,22 @@
   gap-1 h-fit max-h-screen {$$props.class}"
   style={$$props.style}
 >
+<SidebarButton icon={Home} href="/">
+  <span slot="label">
+    {$t('nav.home')}
+  </span>
+</SidebarButton>
+<SidebarButton icon={Cog6Tooth} href="/settings">
+  <span slot="label">
+    {$t('nav.menu.settings')}
+  </span>
+</SidebarButton>
+<SidebarButton icon={GlobeAlt} href="/communities">
+  <span slot="label">
+    {$t('nav.communities')}
+  </span>
+</SidebarButton>
+<hr class="border-slate-200 dark:border-zinc-900 my-1" />
   {#if $profile?.jwt}
     <SidebarButton icon={UserCircle} href="/profile/user">
       <span slot="label">

--- a/src/lib/components/ui/sidebar/Sidebar.svelte
+++ b/src/lib/components/ui/sidebar/Sidebar.svelte
@@ -35,6 +35,7 @@
   gap-1 h-fit max-h-screen {$$props.class}"
   style={$$props.style}
 >
+{#if $userSettings.legacySidebarNavigation}
 <SidebarButton icon={Home} href="/">
   <span slot="label">
     {$t('nav.home')}
@@ -51,6 +52,7 @@
   </span>
 </SidebarButton>
 <hr class="border-slate-200 dark:border-zinc-900 my-1" />
+{/if}
   {#if $profile?.jwt}
     <SidebarButton icon={UserCircle} href="/profile/user">
       <span slot="label">
@@ -88,13 +90,15 @@
     >
       <span slot="label">{$t('account.signup')}</span>
     </SidebarButton>
-    <SidebarButton
+    {#if $userSettings.legacySidebarNavigation === false}
+      <SidebarButton
       href="/settings"
       title={$t('nav.menu.settings')}
       icon={Cog6Tooth}
-    >
-      <span slot="label">{$t('nav.menu.settings')}</span>
-    </SidebarButton>
+      >
+        <span slot="label">{$t('nav.menu.settings')}</span>
+      </SidebarButton>
+    {/if}
   {/if}
   {#if $profileData.profiles.length >= 1}
     <hr class="border-slate-200 dark:border-zinc-900 my-1" />

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -547,6 +547,10 @@
         "on": "On",
         "off": "Off",
         "adaptive": "Adaptive"
+      },
+      "legacySidebarNavigation": {
+        "title": "Legacy sidebar navigation",
+        "description": "Use the old sidebar navigation"
       }
     },
     "app": {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -88,6 +88,7 @@ interface Settings {
   }
   language: string | null
   translator: string | undefined
+  legacySidebarNavigation: boolean
 }
 
 export const defaultSettings: Settings = {
@@ -154,6 +155,7 @@ export const defaultSettings: Settings = {
   },
   language: env.PUBLIC_LANGUAGE ?? null,
   translator: env.PUBLIC_TRANSLATOR ?? undefined,
+  legacySidebarNavigation: toBool(env.PUBLIC_LEGACY_SIDEBAR_NAVIGATION) ?? false,
 }
 
 export const userSettings = writable(defaultSettings)

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -88,6 +88,11 @@
         bind:selected={$userSettings.dock.noGap}
       />
     </Setting>
+    <ToggleSetting
+      bind:checked={$userSettings.legacySidebarNavigation}
+      title={$t('settings.navigation.legacySidebarNavigation.title')}
+      description={$t('settings.navigation.legacySidebarNavigation.description')}
+    />
   </Section>
 
   <Section title={$t('settings.app.title')}>


### PR DESCRIPTION
I think the new navigation layout is too different from the old layout and messes up muscle memory and the frontpage button is also too far away and leads to too much mouse movement for a button that is regularly used.

I have moved the frontpage, settings, and explore buttons back to the sidebar for easier access and kept everything else as is.