### PR TITLE
Stop avatar squish

### DIFF
--- a/src/lib/components/ui/Avatar.svelte
+++ b/src/lib/components/ui/Avatar.svelte
@@ -40,7 +40,7 @@
     {width}
     {title}
     loading="lazy"
-    class="aspect-square object-cover overflow-hidden {$$props.class}"
+    class="aspect-square object-cover overflow-hidden {$$props.class} flex-shrink-0"
     style="width: {width}px; height: {width}px;"
     class:rounded-full={circle}
     class:rounded-md={!circle}
@@ -48,7 +48,7 @@
 {:else}
   <div
     style="width: {width}px; height: {width}px;"
-    class="aspect-square object-cover overflow-hidden {$$props.class}"
+    class="aspect-square object-cover overflow-hidden {$$props.class} flex-shrink-0"
     class:rounded-full={circle}
     class:rounded-md={!circle}
   >


### PR DESCRIPTION
I came across a community with an unreasonably long name. The name doesn't fit, and squishes the icon.

![Screenshot_20240620_170321](https://github.com/Xyphyn/photon/assets/100710152/c5c9a0f1-b751-4990-9af1-2146219358b2)

This is also possible on sitecard, and probably some other places.

Adding `flex-shrink-0` stops it:

![Screenshot_20240620_170307](https://github.com/Xyphyn/photon/assets/100710152/12604d87-2e3d-4a63-8df2-7805c1c8eb7e)

Edit: Closes #345 