### PR TITLE
Compact mode thumbnails

### DIFF
--- a/src/lib/components/lemmy/post/Post.svelte
+++ b/src/lib/components/lemmy/post/Post.svelte
@@ -108,6 +108,7 @@
       <PostMediaCompact
         {view}
         bind:post={post.post}
+        bind:type={type}
         class="{$userSettings.leftAlign
           ? 'mr-2'
           : 'ml-2'} flex-shrink no-list-margin"

--- a/src/lib/components/lemmy/post/media/PostMediaCompact.svelte
+++ b/src/lib/components/lemmy/post/media/PostMediaCompact.svelte
@@ -3,39 +3,62 @@
     bestImageURL,
     optimizeImageURL,
     postLink,
+    type MediaType,
   } from '$lib/components/lemmy/post/helpers.js'
   import { showImage } from '$lib/components/ui/ExpandableImage.svelte'
   import { userSettings } from '$lib/settings.js'
   import { isImage } from '$lib/ui/image'
   import type { Post } from 'lemmy-js-client'
+  import { DocumentText, Icon, Link, VideoCamera } from 'svelte-hero-icons';
 
   export let view: 'card' | 'cozy' | 'list' | 'compact' = 'cozy'
   export let post: Post
+  export let type: MediaType = 'none'
 </script>
 
-{#if (view == 'list' || view == 'compact') && !post.embed_title && (post.thumbnail_url || isImage(post.url))}
+{#if view == "compact" || (view == "list" && !post.embed_title && (post.thumbnail_url || isImage(post.url)))}
   <div
     class="w-24 sm:w-32 h-24 group/media {$$props.class ?? ''}"
     style={$$props.style ?? ''}
   >
     <svelte:element
-      this={!$userSettings.expandImages ||
-      (post.thumbnail_url && !isImage(post.url))
-        ? 'a'
-        : 'button'}
+      this={!$userSettings.expandImages || type != 'image' ? 'a' : 'button'}
       href={postLink(post)}
-      on:click={() => showImage(bestImageURL(post, false, 2048))}
+      on:click={() => {
+        if (type == "image") {
+          showImage(bestImageURL(post, false, 2048));
+        }
+      }}
       role="button"
       tabindex="0"
     >
-      <img
-        src={optimizeImageURL(post.thumbnail_url || post.url || '', 128)}
-        loading="lazy"
-        class="object-cover overflow-hidden bg-slate-100 dark:bg-zinc-800 rounded-xl h-24 w-24 sm:w-32
-        border border-slate-200 dark:border-zinc-800 group-hover/media:border-slate-400
-        group-hover/media:dark:border-zinc-600 transition-colors"
-        alt={post.name}
-      />
+      {#if post.thumbnail_url || isImage(post.url)}
+        <img
+          src={optimizeImageURL(post.thumbnail_url || post.url || '', 128)}
+          loading="lazy"
+          class="object-cover overflow-hidden bg-slate-100 dark:bg-zinc-800 rounded-xl h-24 w-24 sm:w-32
+          border border-slate-200 dark:border-zinc-800 group-hover/media:border-slate-400
+          group-hover/media:dark:border-zinc-600 transition-colors"
+          alt={post.name}
+        />
+        {#if type != 'image'}
+          <div
+            class="relative w-7 h-7 bottom-8 left-1 rounded-lg text-slate-800 dark:text-zinc-200
+            backdrop-blur-sm bg-[#ffffff]/75 dark:bg-black/75 grid place-items-center"
+          >
+            <Icon src={type == 'iframe' ? VideoCamera : Link} mini size="16"/>
+          </div>
+        {/if}
+      {:else}
+        <div
+          class="object-cover overflow-hidden bg-slate-100 dark:bg-zinc-800 rounded-xl h-24 w-24 sm:w-32
+          border border-slate-200 dark:border-zinc-800 group-hover/media:border-slate-400
+          group-hover/media:dark:border-zinc-600 transition-colors text-slate-400 dark:text-zinc-600 grid
+          place-items-center"
+        >
+          <Icon src={type == 'embed' ? Link : DocumentText} size="32"/>
+        </div>
+      {/if}
     </svelte:element>
   </div>
 {/if}

--- a/src/lib/components/lemmy/post/media/PostMediaCompact.svelte
+++ b/src/lib/components/lemmy/post/media/PostMediaCompact.svelte
@@ -56,7 +56,7 @@
           group-hover/media:dark:border-zinc-600 transition-colors text-slate-400 dark:text-zinc-600 grid
           place-items-center"
         >
-          <Icon src={type == 'embed' ? Link : DocumentText} size="32"/>
+          <Icon src={type == 'embed' ? Link : DocumentText} solid size="32"/>
         </div>
       {/if}
     </svelte:element>


### PR DESCRIPTION
![image](https://github.com/Xyphyn/photon/assets/100710152/660bd6cc-d674-4a41-be3f-6a66bcc34dbe)

Related issues: #332 #323

Compact mode has been near useless to me since it doesn't display thumbnails for links. This pr adds just that, and a bit more.

This should only affect behaviour of compact view.

- Embed thumbnails are now shown, with a link icon in the corner
- Video thumbnails are now shown, with a camera icon in the corner
- Self-posts get a placeholder thumbnail, with a text document icon
- Thumbnail-less links get a placeholder thumbnail, with a link icon
- As a happy accidental side effect, this fixes a minor bug when expanding images are disabled: 
Images would expand before loading the post. The expanded image would then show up when going back one page.

![Screenshot_20240621_001929](https://github.com/Xyphyn/photon/assets/100710152/4c6cfcba-2d53-4abf-8cbb-9a2319fae1a3)
![Screenshot_20240621_004251](https://github.com/Xyphyn/photon/assets/100710152/e125c62e-5c86-40bf-bc72-6c591f90f7fd)
![Screenshot_20240621_002053](https://github.com/Xyphyn/photon/assets/100710152/033d7b3a-e8c4-49b7-8c5d-fadee67ecd59)
![Screenshot_20240621_001948](https://github.com/Xyphyn/photon/assets/100710152/e3046e8b-f87d-49b1-b8cd-56049725df27)

The reasoning for the placeholders is from the left align issue. I'm not 100% sure what's the best approach for list view, but for compact, I think this is the way to go.