### PR TITLE
video placeholder thumbnail

### DIFF
--- a/src/lib/components/lemmy/post/media/PostMediaCompact.svelte
+++ b/src/lib/components/lemmy/post/media/PostMediaCompact.svelte
@@ -56,7 +56,7 @@
           group-hover/media:dark:border-zinc-600 transition-colors text-slate-400 dark:text-zinc-600 grid
           place-items-center"
         >
-          <Icon src={type == 'embed' ? Link : DocumentText} solid size="32"/>
+          <Icon src={type == 'embed' ? Link : type == 'iframe' ? VideoCamera : DocumentText} solid size="32"/>
         </div>
       {/if}
     </svelte:element>


### PR DESCRIPTION
Fixes small oversight in #340.

Not all videos have a thumbnail, this adds a placeholder.

![image](https://github.com/Xyphyn/photon/assets/100710152/8af966d2-65c8-4c3e-a8a4-6d28da48229d)
