### PR TITLE
Post meta - Don't wrap

### DIFF
--- a/src/lib/components/lemmy/community/CommunityLink.svelte
+++ b/src/lib/components/lemmy/community/CommunityLink.svelte
@@ -27,25 +27,24 @@
   {/if}
 
   {#if name}
-    <span class="flex gap-0 items-center max-w-full min-w-0 flex-shrink">
-      <span class="font-medium">{community.title}</span>
+    <!-- div text color affects ellipsis. -->
+    <div class="communitylink-text text-slate-500 dark:text-zinc-500">
+      <span class="font-medium text-slate-950 dark:text-zinc-50">
+        {community.title}
+      </span>
       {#if showInstance}
-        <span
-          class="text-slate-500 dark:text-zinc-500 font-normal
-          instance-text flex-shrink {$$props.instanceClass || ''}"
-        >
+        <span class="-ml-1 {$$props.instanceClass || ''}">
           @{new URL(community.actor_id).hostname}
         </span>
       {/if}
-    </span>
+    </div>
   {/if}
 </a>
 
 <style>
-  .instance-text {
+  .communitylink-text {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 100%;
   }
 </style>

--- a/src/lib/components/lemmy/post/PostMeta.svelte
+++ b/src/lib/components/lemmy/post/PostMeta.svelte
@@ -46,9 +46,7 @@
 </script>
 
 <div
-    class="grid w-full meta {community
-        ? 'grid-rows-2'
-        : 'grid-rows-1'} text-xs min-w-0 max-w-full"
+    class="flex flex-row w-full text-xs min-w-48"
     style={$$props.style ?? ""}
 >
     {#if community}
@@ -68,7 +66,7 @@
                     url={community.icon}
                     width={28}
                     alt={community.name}
-                    style="grid-area: avatar; height: 100%;"
+                    style="height: 100%;"
                     class="flex-shrink-0"
                 />
                 {#if subscribed != undefined && $profile?.jwt}
@@ -90,36 +88,30 @@
             </button>
         </Subscribe>
     {/if}
-    {#if community}
-        <CommunityLink
-            {community}
-            style="grid-area: community;"
-            class="flex-shrink"
-        />
-    {/if}
-    <span
-        class="text-slate-600 dark:text-zinc-400 flex flex-row gap-2 items-center"
-        style="grid-area: stats;"
-    >
-        {#if user}
-            <UserLink avatarSize={20} {user} avatar={!community}>
-                <svelte:fragment slot="badges">
-                    {#if badges.moderator}
-                        <ShieldIcon filled width={14} class="text-green-500" />
-                    {/if}
-                    {#if badges.admin}
-                        <ShieldIcon filled width={14} class="text-red-500" />
-                    {/if}
-                </svelte:fragment>
-            </UserLink>
+    <div class="flex flex-col min-w-32 mr-1">
+        {#if community}
+            <CommunityLink {community}/>
         {/if}
-        {#if published}
-            <RelativeDate date={published} class="flex-shrink-0" />
-        {/if}
-    </span>
+        <div class="text-slate-600 dark:text-zinc-400 flex flex-row gap-2 items-center">
+            {#if user}
+                <UserLink avatarSize={20} {user} avatar={!community}>
+                    <svelte:fragment slot="badges">
+                        {#if badges.moderator}
+                            <ShieldIcon filled width={14} class="text-green-500 flex-shrink-0" />
+                        {/if}
+                        {#if badges.admin}
+                            <ShieldIcon filled width={14} class="text-red-500 flex-shrink-0" />
+                        {/if}
+                    </svelte:fragment>
+                </UserLink>
+            {/if}
+            {#if published}
+                <RelativeDate date={published} class="flex-shrink-0" />
+            {/if}
+        </div>
+    </div>
     <div
         class="flex flex-row items-center self-center flex-wrap gap-2 [&>*]:flex-shrink-0 badges"
-        style="grid-area: badges;"
     >
         {#if badges.nsfw}
             <Badge
@@ -199,15 +191,3 @@
         <Markdown source={title} inline noStyle class="leading-6"></Markdown>
     </a>
 {/if}
-
-<style>
-    .meta {
-        display: grid;
-        grid-template-areas:
-            "avatar community badges"
-            "avatar stats badges";
-        gap: 0;
-        grid-template-rows: auto auto;
-        grid-template-columns: auto 1fr;
-    }
-</style>

--- a/src/lib/components/lemmy/user/UserLink.svelte
+++ b/src/lib/components/lemmy/user/UserLink.svelte
@@ -28,22 +28,21 @@
       class="flex-shrink-0"
     />
   {/if}
-  <span
-    class="flex gap-0 items-center flex-shrink max-w-full min-w-0"
+  <!-- div text color affects ellipsis. -->
+  <div
+    class="text-slate-500 dark:text-zinc-500 userlink-text"
     class:ml-0.5={avatar}
   >
-    <span class:font-medium={showInstance}>
+    <span class:font-medium={showInstance} class="text-slate-600 dark:text-zinc-400">
       {$userSettings.displayNames ? user.display_name || user.name : user.name}
     </span>
     {#if showInstance}
-      <span
-        class="text-slate-500 dark:text-zinc-500 font-normal instance-text flex-shrink {$$props.instanceClass ??
-          ''}"
-      >
+      <span class="-ml-1 {$$props.instanceClass ?? ''}">
         @{new URL(user.actor_id).hostname}
       </span>
     {/if}
-  </span>
+  </div>
+
   {#if badges}
     {#if user.banned}
       <div class="text-red-500" title="Banned">
@@ -58,10 +57,9 @@
 </a>
 
 <style>
-  .instance-text {
+  .userlink-text {
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
-    max-width: 100%;
   }
 </style>


### PR DESCRIPTION
Related issues: #342 

I'm trying to make sure that user and community links in meta don't wrap.

Before:
![Screenshot_20240702_152222](https://github.com/Xyphyn/photon/assets/100710152/83762625-f9ab-4698-a3d5-37281db42cfa)

After:
![Screenshot_20240702_211113](https://github.com/Xyphyn/photon/assets/100710152/74d0b1a6-aec3-4bf3-bde4-27a2f1f95c72)

Changes:
- Meta links should always stay on one line and cut off nicely.
  - Replaced meta grid layout with a flex row with a nested flex column inside. I have doubts on whether I should've touched it, but that's how I managed to get this work.
- Mod & admin shields don't shrink anymore.
- Set minimum width for the entire meta div to allow shrinking. This stops posts from overflowing or meta overlapping with thumbnail. The layout is still bad, but it's less bad.
<details>
 <summary>layout before</summary>

![Screenshot_20240702_210640](https://github.com/Xyphyn/photon/assets/100710152/391f38ec-d1fb-4ac9-851f-2cdfb9953755)
</details>


<details>
 <summary>layout after</summary>

![Screenshot_20240702_210702](https://github.com/Xyphyn/photon/assets/100710152/02c18dc5-1366-4a14-a3dc-3422b0b82760)
</details>




