### PR TITLE
Remove empty space left by hideTitle

### DIFF
--- a/src/lib/components/lemmy/post/PostMeta.svelte
+++ b/src/lib/components/lemmy/post/PostMeta.svelte
@@ -183,6 +183,8 @@
   >
     <Markdown source={title} inline noStyle class="leading-[1.3]"></Markdown>
   </a>
+{:else}
+  <div style="grid-area: title; margin: 0;"></div>
 {/if}
 
 <style>


### PR DESCRIPTION
Before:
![image](https://github.com/Xyphyn/photon/assets/100710152/80fdf0f4-0c5f-457c-9ff8-a0cbfb7d665e)
After:
![image](https://github.com/Xyphyn/photon/assets/100710152/153886ad-4bcb-47dd-8405-c44d9b74f13c)

I added a placeholder zero-height div to occupy the unused grid slot.