### PR TITLE
Vertical postlink layout for mobile

### DIFF
--- a/src/lib/components/lemmy/post/PostLink.svelte
+++ b/src/lib/components/lemmy/post/PostLink.svelte
@@ -19,7 +19,7 @@
   For embed-type posts. Displays embed card or a compact link.
 -->
 {#if embed_title && !compact}
-  <Material color="distinct" class="flex flex-row gap-4">
+  <Material color="distinct" class="flex flex-col-reverse sm:flex-row overflow-hidden gap-4">
     <div class="flex flex-col gap-2">
       {#if richURL}
         <Link
@@ -50,7 +50,7 @@
       <a
         href={url}
         target="_blank"
-        class="ml-auto w-full thumbnail rounded-r-lg overflow-hidden flex-shrink -m-4"
+        class="-m-4 mb-auto sm:-mb-4 sm:ml-auto flex-shrink-0 sm:w-[30%] sm:max-w-60"
       >
         <img
           src={optimizeImageURL(thumbnail_url, 256)}
@@ -97,10 +97,3 @@
     </a>
   {/if}
 {/if}
-
-<style>
-  .thumbnail {
-    max-width: 240px;
-    height: calc(100%+16px);
-  }
-</style>

--- a/src/lib/components/lemmy/post/PostLink.svelte
+++ b/src/lib/components/lemmy/post/PostLink.svelte
@@ -50,7 +50,7 @@
       <a
         href={url}
         target="_blank"
-        class="-m-4 mb-auto sm:-mb-4 sm:ml-auto flex-shrink-0 sm:w-[30%] sm:max-w-60"
+        class="-m-4 mb-auto sm:-mb-4 sm:ml-auto flex-shrink-0 sm:w-1/3 sm:max-w-60"
       >
         <img
           src={optimizeImageURL(thumbnail_url, 256)}


### PR DESCRIPTION
Before:
![Screenshot_20240712_161239](https://github.com/user-attachments/assets/967e181c-a859-495f-b57c-6aea72227f50)

After:
![Screenshot_20240712_161215](https://github.com/user-attachments/assets/5a895918-e68b-4371-92ea-bf2c47fa4b63)

Related issues: #342

Proposal for better thumbnails on mobile.

Changes:
- New vertical layout created: Thumbnail is placed above the text on narrow screens.
- Old horizontal layout changed: thumbnail width is now consistent.