### PR TITLE
fix: infinite scroll too wide for mobile

### DIFF
--- a/src/lib/components/lemmy/post/feed/VirtualFeed.svelte
+++ b/src/lib/components/lemmy/post/feed/VirtualFeed.svelte
@@ -267,7 +267,7 @@
       </div>
     {:else if hasMore}
       <div class="w-full flex flex-col skeleton gap-2 animate-pulse pt-6">
-        <div class="w-96 h-8"></div>
+        <div class="w-96 max-w-full h-8"></div>
         <div class="w-full h-48"></div>
         <div class="!bg-transparent h-8 flex justify-between">
           <div class="w-48 h-8"></div>


### PR DESCRIPTION
Closes #342 again.

The culprit was this box.
![image](https://github.com/user-attachments/assets/70cd181e-2035-4b03-ac49-9b63d0413c6d)

One unit is 4px, making w-96 is too much for 360px screens.

Changes:
- Added width limit