### PR TITLE
feat: Recognize m.youtube.com links

### DIFF
--- a/src/lib/components/lemmy/post/helpers.ts
+++ b/src/lib/components/lemmy/post/helpers.ts
@@ -56,7 +56,7 @@ export const optimizeImageURL = (
 }
 
 const YOUTUBE_REGEX =
-  /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
+  /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
 
 export const isYoutubeLink = (url?: string): RegExpMatchArray | null => {
   if (!url) return null


### PR DESCRIPTION
As the title says.

Regex is such a pleasant thing to work with.

Changes:
- m.youtube.com links are now recognized.

Bonus features:
- Doesn't break youtube.com links.
- Doesn't break youtu.be links.