### PR TITLE
fix: m.youtube.com embeds

### DIFF
--- a/src/lib/components/lemmy/post/media/PostIframe.svelte
+++ b/src/lib/components/lemmy/post/media/PostIframe.svelte
@@ -15,7 +15,7 @@
 
   function youtubeVideoID(url: string): string | null {
     const regex =
-      /^(?:https?:\/\/)?(?:www\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
+      /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
     const match = url.match(regex)
 
     if (match && match[1]) {


### PR DESCRIPTION
Related to #366.

This was pretty dumb on my part: The video shows up so I somehow didn't realize I should try if it actually plays.

<details>

![image](https://github.com/user-attachments/assets/435dba1f-ab7a-40fe-914b-6a6f99d4053d)
</details>

Now the iframe gets a video id and works.

<details>

![image](https://github.com/user-attachments/assets/1ba16b43-df25-4862-a41e-99a99fab02a8)
</details>