### PR TITLE
feat: feed end indicator

### DIFF
--- a/src/lib/components/lemmy/post/feed/VirtualFeed.svelte
+++ b/src/lib/components/lemmy/post/feed/VirtualFeed.svelte
@@ -274,6 +274,10 @@
           <div class="w-24 h-8"></div>
         </div>
       </div>
+    {:else}
+      <div class="w-full flex justify-center pt-4 text-sm text-slate-500 dark:text-zinc-500">
+        You have reached the end of {feedData.community_name ?? "the feed"}.
+      </div>
     {/if}
     <InfiniteScroll window threshold={1000} on:loadMore={loadMore} />
   {/if}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/e302e306-cb4f-4962-b19c-60a6fe2e19ed)
![image](https://github.com/user-attachments/assets/b99981a1-bd04-40cd-a57a-bd4c0d168e19)

Changes:
- Add this piece of text to the end of the infinite feed.

Like some of my other contributions, I just kinda built something quick and then see what happens at the pull request. It lacks translations as there wasn't an obvious category in the json and the "no posts" message in the same file hasn't been translated either.