### PR TITLE
feat: youtube livestream iframe

### DIFF
--- a/src/lib/components/lemmy/post/helpers.ts
+++ b/src/lib/components/lemmy/post/helpers.ts
@@ -56,7 +56,7 @@ export const optimizeImageURL = (
 }
 
 const YOUTUBE_REGEX =
-  /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
+  /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|live\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
 
 export const isYoutubeLink = (url?: string): RegExpMatchArray | null => {
   if (!url) return null

--- a/src/lib/components/lemmy/post/media/PostIframe.svelte
+++ b/src/lib/components/lemmy/post/media/PostIframe.svelte
@@ -15,7 +15,7 @@
 
   function youtubeVideoID(url: string): string | null {
     const regex =
-      /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
+      /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|live\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
     const match = url.match(regex)
 
     if (match && match[1]) {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/cabf39b5-ab82-4dc4-be8c-61d701bba40d)
![image](https://github.com/user-attachments/assets/ca8ae018-644f-49e2-b373-1ca18609bcc6)

(https://lemmy.world/post/17853161)

Related issues: #367 

Changes:
- Recognize `/live/` urls in youtube regex. YT livestreams are now embedded.