### PR TITLE
fix: hide guest actions in locked instance mode

### DIFF
--- a/src/routes/accounts/+page.svelte
+++ b/src/routes/accounts/+page.svelte
@@ -244,10 +244,12 @@
                 {$t('common.debug')}
               </MenuButton>
             {/if}
-            <MenuButton on:click={() => action(profile)} color="danger-subtle">
-              <Icon slot="prefix" src={ArrowRightOnRectangle} size="16" mini />
-              {$t('account.logout')}
-            </MenuButton>
+            {#if !LINKED_INSTANCE_URL || profile.user}
+              <MenuButton on:click={() => action(profile)} color="danger-subtle">
+                <Icon slot="prefix" src={ArrowRightOnRectangle} size="16" mini />
+                {$t('account.logout')}
+              </MenuButton>
+            {/if}
           </Menu>
         </div>
       {/each}

--- a/src/routes/login/+page.svelte
+++ b/src/routes/login/+page.svelte
@@ -143,10 +143,12 @@
         <Icon src={QuestionMarkCircle} mini size="16" />
         {$t('form.forgotpassword')}
       </Button>
-      <Button color="tertiary" href="/login/guest">
-        <Icon src={UserCircle} mini size="16" />
-        {$t('account.guest')}
-      </Button>
+      {#if !LINKED_INSTANCE_URL}
+        <Button color="tertiary" href="/login/guest">
+          <Icon src={UserCircle} mini size="16" />
+          {$t('account.guest')}
+        </Button>
+      {/if}
     </div>
   </form>
 </div>


### PR DESCRIPTION
Related issues: #328

This hides guest login / logout buttons if photon is linked to an instance. Adding guests doesn't work with linked instances, which made guest logout especially infuriating since the only way I could get the guest user back was by removing logged in accounts.

<details>
<summary> Before </summary>

![Screenshot_20240725_133540](https://github.com/user-attachments/assets/8759920c-7bc0-45d4-bca0-afa904b222ce)

![image](https://github.com/user-attachments/assets/c76a1e20-6799-48f2-ae43-f4b22455cd88)

</details>

<details>
<summary> After </summary>

![Screenshot_20240725_134112](https://github.com/user-attachments/assets/8d26bb81-8363-48ac-a075-0abaa3a76905)

![Screenshot_20240725_133601](https://github.com/user-attachments/assets/d88edf07-13a7-4b00-8742-a7ccb66a35e1)

</details>


