### PR TITLE
Bottom padding to subscribe button.

### DIFF
--- a/src/lib/components/lemmy/community/CommunityCard.svelte
+++ b/src/lib/components/lemmy/community/CommunityCard.svelte
@@ -245,7 +245,7 @@
     {/if}
   </div>
   <div
-    class="flex flex-row items-center gap-1 sticky bottom-0 drop-shadow-xl w-full"
+    class="flex flex-row items-center gap-1 sticky bottom-0 drop-shadow-xl w-full pb-4"
   >
     {#if $profile?.jwt}
       <Button


### PR DESCRIPTION
A minimal change.

I came across a sub that has a sidebar taller than my monitor. The subscribe button is pushed all the way to the the very bottom edge of the browser window. I added some padding to make it float a tiny bit above the edge.

## Before:
![Screenshot_20240813_155904](https://github.com/user-attachments/assets/ce34c596-a3ba-48ba-8238-19cd8de3f447)
![Screenshot_20240813_155925](https://github.com/user-attachments/assets/03b35793-254c-4ba1-8030-1aa6d5313853)

## After:
![Screenshot_20240813_155943](https://github.com/user-attachments/assets/67c54f0a-2183-471d-8d88-ebd7cd392a0a)
![Screenshot_20240813_155955](https://github.com/user-attachments/assets/bc59eab6-8c59-49bd-9758-85dc367244c5)
