### PR TITLE
PostActions fix overflow and wrap

### DIFF
--- a/src/lib/components/lemmy/post/PostActions.svelte
+++ b/src/lib/components/lemmy/post/PostActions.svelte
@@ -225,16 +225,16 @@
       link
       href="/u/{post.creator.name}@{new URL(post.creator.actor_id).hostname}"
     >
-      <Icon src={UserCircle} size="16" micro slot="prefix" />
-      <span>{post.creator.name}</span>
+      <Icon src={UserCircle} size="16" micro slot="prefix" class="flex-shrink-0" />
+      <span class="overflow-hidden overflow-ellipsis whitespace-nowrap">{post.creator.name}</span>
     </MenuButton>
     <MenuButton
       link
       href="/c/{post.community.name}@{new URL(post.community.actor_id)
         .hostname}"
     >
-      <Icon src={Newspaper} size="16" micro slot="prefix" />
-      <span>{post.community.title}</span>
+      <Icon src={Newspaper} size="16" micro slot="prefix" class="flex-shrink-0" />
+      <span class="overflow-hidden overflow-ellipsis whitespace-nowrap">{post.community.title}</span>
     </MenuButton>
     <MenuButton
       loading={fediseerLoading}
@@ -256,10 +256,10 @@
         {#if fediseerLoading}
           <Spinner width={14} />
         {:else}
-          <Icon src={ServerStack} size="16" micro />
+          <Icon src={ServerStack} size="16" micro class="flex-shrink-0" />
         {/if}
       </svelte:fragment>
-      <span>{new URL(post.community.actor_id).hostname}</span>
+      <span class="overflow-hidden overflow-ellipsis whitespace-nowrap">{new URL(post.community.actor_id).hostname}</span>
     </MenuButton>
     <hr class="w-[90%] mx-auto opacity-100 dark:opacity-10 my-2" />
     <MenuDivider>{$t('post.actions.more.actions')}</MenuDivider>


### PR DESCRIPTION
Minor CSS changes to PostActions:

**Before:**
![Screenshot_20240907_132051](https://github.com/user-attachments/assets/869e0a30-da6f-49e9-b450-14fa368bff5c)
- The community name is long and wraps to multiple lines.
- The icon has shrunk under the weight of this community name.


**After:**
![image](https://github.com/user-attachments/assets/2a958744-19e8-4b6c-a0a2-e6a5c67c5688)
All of these fields overflow like this now.
- Overflow-ellipsis, nowrap for the text
- Icons don't shrink