### PR TITLE
Remove redundant <hr> tags within expandable headers

### DIFF
--- a/src/lib/components/ui/EndPlaceholder.svelte
+++ b/src/lib/components/ui/EndPlaceholder.svelte
@@ -3,9 +3,8 @@
    text-sm text-slate-600 dark:text-zinc-400 gap-2 flex-wrap {$$props.class ||
     ''}"
 >
-  <span class="font-medium text-left">
+  <span class="flex-1 font-medium text-left">
     <slot />
   </span>
-  <hr class="border-slate-200 flex-1 w-full dark:border-zinc-800" />
   <slot name="action" />
 </div>


### PR DESCRIPTION
There are `<hr>` tags within the expandable headers, the clickable components that expand or collapse when you click on them (for example, at the left sidebar of the home page on desktop) that seem redundant to me, as the expandable headers themselves are separated with more `<hr>` tags - so they look a bit cluttered:

![Captura de pantalla_20240908_201723](https://github.com/user-attachments/assets/a245a436-990c-413c-9a34-fd15eb6c4c42)

 I'd like if you consider removing this `<hr>` tags placed within this expandable headers and giving said sidebars a cleaner look:
  
![Captura de pantalla_20240908_201805](https://github.com/user-attachments/assets/a6514b66-ab1d-4f7f-b0e0-345f8f97c9f9)