### PR TITLE
design: increase postlink margin

### DIFF
--- a/src/lib/components/lemmy/post/link/PostLink.svelte
+++ b/src/lib/components/lemmy/post/link/PostLink.svelte
@@ -46,7 +46,7 @@
         -inset-px"
       />
     {/if}
-    <div class="flex flex-col gap-2 mb-2">
+    <div class="flex flex-col gap-2 mb-4">
       {#if richURL}
         <Link
           href={url}


### PR DESCRIPTION
Another tiny style change. Link options are uncomfortably close to the text, and even partially covers some letters. I added the tiniest amount of margin under the link preview to fix this.

**Before:**
![image](https://github.com/user-attachments/assets/9f76de86-cc33-4dd1-8ae8-3bb5ef969cbf)

**After:**
![image](https://github.com/user-attachments/assets/a29d64bc-1acb-43e9-9ae9-aaafccac499f)
