### PR TITLE
design: adjust site banner

### DIFF
--- a/src/lib/components/lemmy/SiteCard.svelte
+++ b/src/lib/components/lemmy/SiteCard.svelte
@@ -30,15 +30,19 @@
 
 <StickyCard class="w-full {$$props.class} text-slate-600 dark:text-zinc-400">
   {#if site.site.banner}
-    <div
-      class="rounded-xl
-     bg-slate-100 dark:bg-zinc-925"
-    >
+    <div class="h-36 -ml-2 -mr-2 flex justify-center">
       <img
         src={optimizeImageURL(site.site.banner, 512)}
         alt="Site banner"
-        class="h-32 object-cover w-full"
-        style="border-radius: inherit;"
+        class="object-contain max-h-full max-w-full rounded-lg"
+        style=""
+      />
+    </div>
+    <div class="absolute top-0 left-0 -z-10 object-cover w-full">
+      <img
+        src={optimizeImageURL(site.site.banner, 64)}
+        alt=""
+        class="opacity-10 blur-2xl h-full w-full object-cover saturate-200"
       />
     </div>
   {/if}


### PR DESCRIPTION
closes #431 

I've been trying to come up with a better way to display site banners.

It had to show the full image. Banners can lose meaning, or look terrible if not shown fully. And at the same time background image -style banners shouldn't suffer from this.

**Changes:**
- Show the whole image.
- Replace fixed height with max-height.
- Remove background color to make banner images feel more "integrated"
- Added blurred banner image background. It's pretty faint, and could probably look better with adjustment.
- Decreased horizontal margin by a small amount.


It isn't perfect, but it's the best compromise that I could come up with for all the different types of site banner.

<details>
<summary>Before / After:</summary>

![image](https://github.com/user-attachments/assets/30c1c21c-a47b-48fa-9517-13f6f240e42f)
![image](https://github.com/user-attachments/assets/9981a772-d9cf-4a78-a8ff-21a4f93797d5)
___
![image](https://github.com/user-attachments/assets/26a3c642-16fc-4153-8aff-efeeca18e580)
![image](https://github.com/user-attachments/assets/818d7b98-a396-4d18-8a64-1dd5498c948d)
___
![image](https://github.com/user-attachments/assets/d161a53f-14dc-4270-bb51-f1eff98a356a)
![image](https://github.com/user-attachments/assets/7aca349b-8e57-42b0-ac55-276eb1d6eca9)
___
![image](https://github.com/user-attachments/assets/690003a6-706e-4e08-b742-e228cb82117f)
![image](https://github.com/user-attachments/assets/5933fe09-35dc-408f-9690-4092fc2b7747)
___
![image](https://github.com/user-attachments/assets/ea69eebd-89cf-42e5-afca-9a03d759b737)
![image](https://github.com/user-attachments/assets/230615d8-be58-4169-b4ab-eaab4aebcea5)

</details>