### PR TITLE
fix: post page has no edit icon

### DIFF
--- a/src/routes/post/[instance]/[id=integer]/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/+page.svelte
@@ -204,6 +204,7 @@
           moderator: post.post_view.creator_is_moderator,
         }}
         published={publishedToDate(post.post_view.post.published)}
+        edited={post.post_view.post.updated != undefined}
         bind:title={post.post_view.post.name}
         style="width: max-content;"
       />


### PR DESCRIPTION
Related issues: #406

The pencil icon for edited posts didn't show up in full post view. Fixed.