### PR TITLE
cleanup: switch to a css-based navbar

### DIFF
--- a/src/lib/components/ui/layout/Shell.svelte
+++ b/src/lib/components/ui/layout/Shell.svelte
@@ -1,98 +1,8 @@
-<script lang="ts" module>
-  import { innerWidth, scrollY } from 'svelte/reactivity/window'
-
-  const calculateDockProperties = (
-    settings: {
-      top: boolean | null
-      noGap: boolean | null
-    },
-    screenWidth: number,
-  ): {
-    noGap: boolean
-    top: boolean
-  } => {
-    let panel = false
-    let top = false
-
-    if (screenWidth >= 1024) {
-      panel = true
-      top = true
-    }
-
-    panel = settings.noGap ?? panel
-    top = settings.top ?? top
-
-    return {
-      noGap: panel,
-      top: top,
-    }
-  }
-
-  export const calculatePadding = (
-    panel: boolean,
-    top: boolean,
-    content: boolean,
-  ): {
-    top: number
-    bottom: number
-    class: string
-  } => {
-    if (panel) {
-      if (top) {
-        if (content) return { top: 80, class: '!pt-20', bottom: 0 }
-        else
-          return {
-            top: 64,
-            class: 'top-16 !max-h-[calc(100vh-4rem)]',
-            bottom: 0,
-          }
-      } else return { top: 0, class: '!pb-20', bottom: 80 }
-    } else {
-      if (!content) return { top: 0, class: '', bottom: 0 }
-
-      if (top) return { top: 96, class: '!pt-24', bottom: 0 }
-      else return { top: 0, class: '!pb-24', bottom: 96 }
-    }
-
-    return { top: 0, class: ' failed-to-calculate', bottom: 0 }
-  }
-
-  let dockProps = $derived(
-    calculateDockProperties(settings.dock, innerWidth.current ?? 1000),
-  )
-  let contentPadding = $derived(
-    calculatePadding(dockProps.noGap, dockProps.top, true),
-  )
-
-  let contentPaddingStore = writable<{
-    top: number
-    bottom: number
-    class: string
-  }>(contentPadding)
-  let dockPropsStore = writable<{
-    noGap: boolean
-    top: boolean
-  }>(dockProps)
-
-  $effect.root(() => {
-    $effect(() => {
-      dockPropsStore.set(
-        calculateDockProperties(settings.dock, innerWidth.current ?? 1000),
-      )
-      contentPaddingStore.set(
-        calculatePadding(dockProps.noGap, dockProps.top, true),
-      )
-    })
-  })
-
-  export { contentPaddingStore as contentPadding, dockPropsStore as dockProps }
-</script>
-
 <script lang="ts">
   import { settings } from '$lib/settings.svelte.js'
   import { theme } from '$lib/ui/colors.svelte'
-  import { writable, type Readable, type Writable } from 'svelte/store'
   import type { ClassValue, UIEventHandler } from 'svelte/elements'
+  import { scrollY } from 'svelte/reactivity/window'
 
   interface Props {
     route?: { id: string | null } | undefined
@@ -118,7 +28,7 @@
 
   let previousTop = 0
   const onscroll: UIEventHandler<Window> = (e) => {
-    dockVisible = (scrollY?.current ?? 0) > previousTop
+    dockVisible = (scrollY?.current ?? 0) <= previousTop
 
     previousTop = scrollY?.current ?? 0
   }
@@ -136,8 +46,8 @@
   {@render children?.()}
   <div
     class="fixed lg:sticky bottom-0 {dockVisible
-      ? 'max-lg:-bottom-24'
-      : ''}  lg:top-0
+      ? ''
+      : 'max-lg:-bottom-24'}  lg:top-0
     max-w-3xl p-4 left-1/2 -translate-x-1/2 lg:max-w-full lg:p-0 lg:left-0 lg:translate-x-0
     w-full z-50 pointer-events-none"
     style="grid-area: navbar;
@@ -160,7 +70,7 @@
       style: 'grid-area: sidebar; width: 100% !important;',
     })}
     {@render main?.({
-      class: `w-full bg-slate-25 dark:bg-zinc-925 justify-self-center shadow-sm z-0 main`,
+      class: `w-full bg-slate-25 dark:bg-zinc-925 justify-self-center shadow-sm z-0 main !pb-22 lg:!pb-0`,
       style: 'grid-area: main',
     })}
     {@render suffix?.({

--- a/src/lib/components/ui/layout/Shell.svelte
+++ b/src/lib/components/ui/layout/Shell.svelte
@@ -28,6 +28,11 @@
 
   let previousTop = 0
   const onscroll: UIEventHandler<Window> = (e) => {
+    if (!settings.dock.autoHide) {
+      dockVisible = true
+      return
+    }
+
     dockVisible = (scrollY?.current ?? 0) <= previousTop
 
     previousTop = scrollY?.current ?? 0

--- a/src/lib/components/ui/layout/pages/Header.svelte
+++ b/src/lib/components/ui/layout/pages/Header.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { settings } from '$lib/settings.svelte'
-  import { contentPadding } from '../Shell.svelte'
 
   interface Props {
     pageHeader?: boolean
@@ -24,14 +23,11 @@
   {pageHeader
     ? `w-[calc(100%+2rem)] sm:w-[calc(100%+3rem)]
   bg-slate-50 dark:bg-zinc-950 -m-4 sm:-m-6 mb-0 sm:mb-0 sm:p-6 p-4
-   border-b border-slate-200 dark:border-zinc-800`
+   border-b border-slate-200 dark:border-zinc-800 margin`
     : ''}
   
   "
-  style="{pageHeader
-    ? `margin-top: min(-12rem, calc(-1 * calc(${$contentPadding.top}px))); padding-top: max(12rem, calc(${$contentPadding.top}px));`
-    : ''} {style};
-"
+  {style}
 >
   <h1
     class="text-3xl font-medium flex gap-2 w-full
@@ -45,3 +41,17 @@
     </div>
   {/if}
 </div>
+
+<style>
+  .margin {
+    margin-top: -12rem;
+    padding-top: 12rem;
+  }
+
+  @media screen and (min-width: 1024px) {
+    .margin {
+      margin-top: -4rem;
+      padding-top: 4rem;
+    }
+  }
+</style>

--- a/src/lib/components/ui/navbar/NavButton.svelte
+++ b/src/lib/components/ui/navbar/NavButton.svelte
@@ -1,8 +1,7 @@
 <script lang="ts">
   import { page } from '$app/state'
-  import { Button } from 'mono-svelte'
+  import { Button, buttonColor } from 'mono-svelte'
   import { Icon, type IconSource } from 'svelte-hero-icons'
-  import { dockProps } from '../layout/Shell.svelte'
   import type { ButtonProps } from 'mono-svelte/button/Button.svelte'
 
   interface Props extends ButtonProps {
@@ -19,8 +18,8 @@
 
   let {
     label,
-    icon = undefined,
-    href = undefined,
+    icon,
+    href,
     adaptive = true,
     isSelectedFilter = (path) => href != undefined && path == href,
     class: clazz = '',
@@ -30,35 +29,38 @@
   }: Props = $props()
 
   let isSelected = $derived(isSelectedFilter(page.url.pathname))
-  let isPanel = $derived(adaptive ? $dockProps?.noGap : false)
 </script>
 
 <Button
-  color={isPanel ? 'secondary' : 'tertiary'}
+  color="none"
   {...rest}
-  class="rounded-full w-10 h-10 flex-shrink-0 {adaptive
-    ? '@3xl:h-8 @3xl:px-3 @3xl:rounded-[10px] @3xl:w-auto'
-    : ''} {isSelected
-    ? 'bg-slate-200 dark:bg-zinc-900 text-primary-900 dark:!text-primary-100'
-    : ''} {clazz}"
+  class={[
+    'flex-shrink-0 rounded-full w-10 h-10 lg:w-max lg:h-8 lg:px-3 lg:rounded-xl',
+    isSelected &&
+      'bg-slate-200 dark:bg-zinc-900 text-primary-900 dark:!text-primary-100',
+    !rest.color && buttonColor.tertiary,
+    !rest.color &&
+      'lg:bg-white lg:dark:bg-zinc-900 border lg:border-slate-200 lg:border-b-slate-300 lg:dark:border-zinc-800 lg:dark:border-t-zinc-700/50 lg:hover:bg-slate-100 lg:hover:dark:bg-zinc-800 lg:active:bg-slate-200 lg:active:dark:bg-zinc-950',
+    clazz,
+  ]}
   size="custom"
+  rounding="none"
   {href}
-  rounding="pill"
   title={label}
   style="transition-property: background-color, filter;"
 >
   {#snippet prefix()}
     {#if icon}
-      <Icon
-        src={icon}
-        micro={isPanel}
-        solid={!isPanel && isSelected}
-        size={isPanel ? '16' : '18'}
-      />
+      <div class="lg:hidden">
+        <Icon src={icon} size="18" />
+      </div>
+      <div class="max-lg:hidden">
+        <Icon src={icon} micro solid={isSelected} size="16" />
+      </div>
     {:else}
-      {@render customIcon?.({ size: isPanel ? 16 : 18, isSelected })}
+      {@render customIcon?.({ size: 16, isSelected })}
     {/if}
   {/snippet}
-  <span class="hidden {adaptive ? '@3xl:block' : ''}">{label}</span>
+  <span class="hidden {adaptive ? 'lg:block' : ''}">{label}</span>
   {@render children?.()}
 </Button>

--- a/src/lib/components/ui/navbar/Navbar.svelte
+++ b/src/lib/components/ui/navbar/Navbar.svelte
@@ -50,7 +50,7 @@
     }}
     href="/"
     label={$t('nav.home')}
-    class="ml-2 logo"
+    class="ml-2 lg:ml-2 logo border-0 lg:rounded-full lg:w-10 lg:h-10 lg:!p-0"
     adaptive={false}
   >
     {#snippet customIcon()}

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -698,6 +698,10 @@
             "pins": {
                 "title": "Pins",
                 "description": "Click a pin to send it to the top of the sidebar. Right click a pinned item to remove it."
+            },
+            "autoHide": {
+                "title": "Auto hide dock",
+                "description": "Hides the dock on mobile when you scroll down, re-appears when you scroll up."
             }
         },
         "app": {

--- a/src/lib/mono/button/Button.svelte
+++ b/src/lib/mono/button/Button.svelte
@@ -121,7 +121,7 @@
     animations?: any
     loaderWidth?: number | undefined
     href?: string | undefined
-    class?: string
+    class?: ClassValue
     prefix?: Snippet
     children?: Snippet
     suffix?: Snippet
@@ -133,7 +133,7 @@
 </script>
 
 <script lang="ts">
-  import type { HTMLButtonAttributes } from 'svelte/elements'
+  import type { ClassValue, HTMLButtonAttributes } from 'svelte/elements'
 
   import Spinner from '../loader/Spinner.svelte'
   import type { Snippet } from 'svelte'
@@ -167,19 +167,19 @@
   role={href ? 'link' : 'button'}
   {href}
   {...rest}
-  class="
-      {loading ? buttonColor.secondary : buttonColor[color]}
-      {buttonSize[size]}
-      {buttonRounding[rounding][roundingSide]}
-			{buttonShadow[shadow]}
-      text-sm transition-all font-medium cursor-pointer duration-75
-      disabled:opacity-50 disabled:pointer-events-none
-      {alignment == 'center'
-    ? 'origin-center'
-    : alignment == 'left'
-      ? 'origin-left'
-      : 'origin-right'}
-      {clazz}"
+  class={[
+    loading ? buttonColor.secondary : buttonColor[color],
+    buttonSize[size],
+    buttonRounding[rounding][roundingSide],
+    buttonShadow[shadow],
+    'text-sm transition-all font-medium cursor-pointer duration-75 disabled:opacity-50 disabled:pointer-events-none',
+    alignment == 'center'
+      ? 'origin-center'
+      : alignment == 'left'
+        ? 'origin-left'
+        : 'origin-right',
+    clazz,
+  ]}
   type={submit ? 'submit' : 'button'}
 >
   <div

--- a/src/lib/settings.svelte.ts
+++ b/src/lib/settings.svelte.ts
@@ -85,7 +85,7 @@ interface Settings {
   }
   dock: {
     paletteHotkey: string
-    showOnScroll: boolean
+    autoHide: boolean
   }
   posts: {
     deduplicateEmbed: boolean
@@ -164,7 +164,7 @@ export const defaultSettings: Settings = {
   },
   dock: {
     paletteHotkey: '/',
-    showOnScroll: false,
+    autoHide: true,
   },
   posts: {
     deduplicateEmbed: toBool(env.PUBLIC_DEDUPLICATE_EMBED) ?? true,

--- a/src/lib/settings.svelte.ts
+++ b/src/lib/settings.svelte.ts
@@ -84,9 +84,8 @@ interface Settings {
     piped: string | undefined
   }
   dock: {
-    noGap: boolean | null
-    top: boolean | null
     paletteHotkey: string
+    showOnScroll: boolean
   }
   posts: {
     deduplicateEmbed: boolean
@@ -164,9 +163,8 @@ export const defaultSettings: Settings = {
     piped: undefined,
   },
   dock: {
-    noGap: toBool(env.PUBLIC_DOCK_PANEL) ?? null,
-    top: toBool(env.PUBLIC_DOCK_TOP) ?? null,
     paletteHotkey: '/',
+    showOnScroll: false,
   },
   posts: {
     deduplicateEmbed: toBool(env.PUBLIC_DEDUPLICATE_EMBED) ?? true,

--- a/src/routes/admin/+layout.svelte
+++ b/src/routes/admin/+layout.svelte
@@ -1,7 +1,7 @@
 <script>
   import { notifications } from '$lib/auth.svelte'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
+  import {} from '$lib/components/ui/layout/Shell.svelte'
   import { t } from '$lib/translations'
   import { Badge } from 'mono-svelte'
   /**
@@ -23,8 +23,8 @@
 
 <div class="flex flex-col gap-4 h-full">
   <div
-    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
+    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2
+    top-6 lg:top-22"
   >
     <Tabs
       routes={[

--- a/src/routes/c/[name]/settings/+layout.svelte
+++ b/src/routes/c/[name]/settings/+layout.svelte
@@ -1,9 +1,5 @@
 <script lang="ts">
-  import { goto } from '$app/navigation'
-  import { page } from '$app/state'
-  import MultiSelect from '$lib/components/input/Switch.svelte'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   import { t } from '$lib/translations.js'
   import { fullCommunityName } from '$lib/util.svelte.js'
   import type { PageData } from './$types.js'
@@ -25,8 +21,7 @@
 
 <div class="flex flex-col gap-4 h-full">
   <div
-    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
+    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2 top-6 lg:top-22"
   >
     <Tabs
       routes={[

--- a/src/routes/communities/+page.svelte
+++ b/src/routes/communities/+page.svelte
@@ -26,7 +26,6 @@
   import { t } from '$lib/translations.js'
   import Header from '$lib/components/ui/layout/pages/Header.svelte'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   import SectionTitle from '$lib/components/ui/SectionTitle.svelte'
   import { fly } from 'svelte/transition'
   import { backOut, expoOut } from 'svelte/easing'
@@ -64,10 +63,7 @@
 </Header>
 
 <form method="get" action="/communities" class="contents" bind:this={form}>
-  <div
-    class="mt-4 mb-0 sticky z-30"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
-  >
+  <div class="mt-4 mb-0 sticky z-30 top-6 lg:top-22">
     <Tabs routes={[]} class="p-2 dark:bg-zinc-925/70 shadow-md shadow-black/5">
       <div class="flex gap-2 flex-row items-center w-full text-base h-10">
         <TextInput
@@ -198,10 +194,7 @@
   </ul>
 {/if}
 {#if communities.length > 0}
-  <div
-    class="sticky z-30 mx-auto max-w-full"
-    style="bottom: max(1.5rem, {$contentPadding.bottom}px);"
-  >
+  <div class="sticky z-30 mx-auto max-w-full bottom-22 lg:bottom-6">
     <Tabs routes={[]} class="mx-auto">
       <Pageination
         page={Number(page.url.searchParams.get('page')) || 1}

--- a/src/routes/inbox/+page.svelte
+++ b/src/routes/inbox/+page.svelte
@@ -22,7 +22,6 @@
   import Header from '$lib/components/ui/layout/pages/Header.svelte'
   import { t } from '$lib/translations'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   import { expoOut } from 'svelte/easing'
 
   let { data } = $props()
@@ -82,8 +81,7 @@
 <div class=" gap-2">
   <div
     class="mt-4 mb-0 sticky z-30 mx-auto max-w-full flex gap-2 md:flex-row flex-col
-items-center px-2 w-max"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
+items-center px-2 w-max top-6 lg:top-22"
   >
     <Tabs
       routes={[
@@ -195,8 +193,7 @@ items-center px-2 w-max"
   {/if}
   {#if !(data.page == 1 && (data?.data?.length ?? 0) == 0)}
     <div
-      class="sticky z-30 mx-auto max-w-full self-end mt-auto"
-      style="bottom: max(1.5rem, {$contentPadding.bottom}px);"
+      class="sticky z-30 mx-auto max-w-full self-end mt-auto bottom-22 lg:bottom-6"
     >
       <Tabs routes={[]} class="mx-auto">
         <Pageination

--- a/src/routes/post/[instance]/[id=integer]/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/+page.svelte
@@ -46,7 +46,6 @@
   import { Popover } from 'mono-svelte'
   import { t } from '$lib/translations.js'
   import { resumables } from '$lib/lemmy/item.js'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   import Placeholder from '$lib/components/ui/Placeholder.svelte'
   import CommentListVirtualizer from '$lib/components/lemmy/comment/CommentListVirtualizer.svelte'
   import Header from '$lib/components/ui/layout/pages/Header.svelte'
@@ -146,7 +145,7 @@
       if (res.post) {
         removeToast(id)
         goto(`/post/${instance.data}/${res.post.post.id}`, {}).then(() =>
-          removeToast(id)
+          removeToast(id),
         )
       }
     } catch (err) {
@@ -176,7 +175,7 @@
   let commenting = $state(false)
 
   let remoteView = $derived(
-    page.params.instance?.toLowerCase() != instance.data?.toLowerCase()
+    page.params.instance?.toLowerCase() != instance.data?.toLowerCase(),
   )
 </script>
 
@@ -342,8 +341,7 @@
   <div
     class="sticky mx-auto z-50 max-w-lg w-full min-w-0 flex items-center overflow-auto gap-1
     bg-slate-50/50 dark:bg-zinc-900/50 backdrop-blur-xl border border-slate-200/50 dark:border-zinc-800/50
-    p-1 rounded-full px-2.5 justify-between"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
+    p-1 rounded-full px-2.5 justify-between top-6 lg:top-22"
   >
     <p class="font-medium text-sm flex items-center gap-2">
       <Icon src={InformationCircle} mini size="20" />

--- a/src/routes/profile/+layout.svelte
+++ b/src/routes/profile/+layout.svelte
@@ -4,7 +4,6 @@
 
   import MultiSelect from '$lib/components/input/Switch.svelte'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   import { site } from '$lib/lemmy.svelte'
   import { t } from '$lib/translations'
   import { feature } from '$lib/version'
@@ -31,8 +30,7 @@
 
 <div class="flex flex-col gap-4 h-full z-0">
   <div
-    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
+    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2 top-6 lg:top-22"
   >
     <Tabs
       class="overflow-auto"

--- a/src/routes/saved/+page.svelte
+++ b/src/routes/saved/+page.svelte
@@ -14,7 +14,6 @@
   import { t } from '$lib/translations.js'
   import Header from '$lib/components/ui/layout/pages/Header.svelte'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   import { Select } from 'mono-svelte'
   import {
     Icon,
@@ -86,10 +85,7 @@
     {/each}
   {/if}
 </div>
-<div
-  class="sticky z-30 mx-auto max-w-full"
-  style="bottom: max(1.5rem, {$contentPadding.bottom}px);"
->
+<div class="sticky z-30 mx-auto max-w-full bottom-22 lg:bottom-6">
   <Tabs routes={[]} class="mx-auto">
     <Pageination href={(page) => `?page=${page}`} page={data.page} />
   </Tabs>

--- a/src/routes/search/+page.svelte
+++ b/src/routes/search/+page.svelte
@@ -38,7 +38,6 @@
   import { t } from '$lib/translations.js'
   import Header from '$lib/components/ui/layout/pages/Header.svelte'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   import { goto } from '$app/navigation'
   import Option from 'mono-svelte/forms/select/Option.svelte'
   import Skeleton from '$lib/components/ui/generic/Skeleton.svelte'
@@ -70,10 +69,7 @@
   {$t('routes.search.title')}
 </Header>
 <form method="get" action="/search" class="contents" bind:this={form}>
-  <div
-    class="mt-4 mb-0 sticky z-30"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
-  >
+  <div class="mt-4 mb-0 sticky z-30 top-6 lg:top-22">
     <Tabs routes={[]} class="p-2 dark:bg-zinc-925/70">
       <div class="flex gap-2 flex-row items-center w-full text-base h-10">
         <TextInput

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -174,10 +174,6 @@
     <Icon src={ArrowTopRightOnSquare} size="14" micro />
     {$t('settings.app.title')}
   </Button>
-  <Button href="#nav" size="sm" class="text-xs" rounding="pill">
-    <Icon src={ArrowTopRightOnSquare} size="14" micro />
-    {$t('settings.navigation.title')}
-  </Button>
   <Button href="#embeds" size="sm" class="text-xs" rounding="pill">
     <Icon src={ArrowTopRightOnSquare} size="14" micro />
     {$t('settings.embeds.title')}
@@ -469,46 +465,6 @@
         </div>
       </Setting>
     </div>
-  </Section>
-  <Section id="nav" title={$t('settings.navigation.title')}>
-    <Setting>
-      {#snippet title()}
-        <span>{$t('settings.navigation.dockPos.title')}</span>
-      {/snippet}
-      {#snippet description()}
-        <span>
-          {$t('settings.navigation.dockPos.description')}
-        </span>
-      {/snippet}
-      <MultiSelect
-        options={[true, false, null]}
-        optionNames={[
-          $t('settings.navigation.dockPos.top'),
-          $t('settings.navigation.dockPos.bottom'),
-          $t('settings.navigation.dockPos.adaptive'),
-        ]}
-        bind:selected={settings.dock.top}
-      />
-    </Setting>
-    <Setting>
-      {#snippet title()}
-        <span>{$t('settings.navigation.panel.title')}</span>
-      {/snippet}
-      {#snippet description()}
-        <span>
-          {$t('settings.navigation.panel.description')}
-        </span>
-      {/snippet}
-      <MultiSelect
-        options={[true, false, null]}
-        optionNames={[
-          $t('settings.navigation.panel.on'),
-          $t('settings.navigation.panel.off'),
-          $t('settings.navigation.panel.adaptive'),
-        ]}
-        bind:selected={settings.dock.noGap}
-      />
-    </Setting>
   </Section>
 
   <Section id="embeds" title={$t('settings.embeds.title')}>

--- a/src/routes/settings/+page.svelte
+++ b/src/routes/settings/+page.svelte
@@ -389,6 +389,12 @@
       description={$t('settings.app.limitLayoutWidth.description')}
     />
     <ToggleSetting
+      supportedPlatforms={{ desktop: false, tablet: false, mobile: true }}
+      bind:checked={settings.dock.autoHide}
+      title={$t('settings.navigation.autoHide.title')}
+      description={$t('settings.navigation.autoHide.description')}
+    />
+    <ToggleSetting
       bind:checked={settings.openLinksInNewTab}
       title={$t('settings.app.postsInNewTab.title')}
       description={$t('settings.app.postsInNewTab.description')}

--- a/src/routes/util/+layout.svelte
+++ b/src/routes/util/+layout.svelte
@@ -3,7 +3,6 @@
   import { page } from '$app/state'
   import MultiSelect from '$lib/components/input/Switch.svelte'
   import Tabs from '$lib/components/ui/layout/pages/Tabs.svelte'
-  import { contentPadding } from '$lib/components/ui/layout/Shell.svelte'
   interface Props {
     children?: import('svelte').Snippet
   }
@@ -13,8 +12,7 @@
 
 <div class="flex flex-col gap-2">
   <div
-    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2"
-    style="top: max(1.5rem, {$contentPadding.top}px);"
+    class="sticky mx-auto z-50 max-w-full min-w-0 flex items-center gap-2 top-6 lg:top-22"
   >
     <Tabs
       routes={[


### PR DESCRIPTION
This navbar is more efficient and lighter everywhere, and reduces shift. The only downside is that the customization for panel position was removed.