### PR TITLE
fix: /site caching for svelte-5

### DIFF
--- a/src/lib/lemmy.svelte.ts
+++ b/src/lib/lemmy.svelte.ts
@@ -36,11 +36,16 @@ async function customFetch(
 ): Promise<Response> {
   const f = func ? func : fetch
 
-  if (init)
+  if (init) {
     init.headers = {
       ...init.headers,
       ...(auth ? { authorization: `Bearer ${auth}` } : {}),
     }
+
+    if (auth) {
+      init.cache = 'no-store'
+    }
+  }
 
   if (init?.body && auth) {
     try {


### PR DESCRIPTION
This fixes the https://github.com/Xyphyn/photon/issues/508 by ignoring cache when a auth jwt is provided.
This allows the guest user to still use cache and authenticated user to have fresh data.