### PR TITLE
fix: all comments button doesn't drop thread param in url

### DIFF
--- a/src/routes/post/[instance]/[id=integer]/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/+page.svelte
@@ -352,7 +352,7 @@
       disabled={loading}
       href={data.thread.value.showContext
         ? `/comment/${page.params.instance}/${data.thread.value.showContext}`
-        : undefined}
+        : `/post/${page.params.instance}/${data.post.value.post_view.post.id}`}
       class="hover:bg-white/50 dark:hover:bg-zinc-800/30"
       onclick={data.thread.value.singleThread ? reloadComments : undefined}
     >


### PR DESCRIPTION
Fixes a minor annoyance I've had.

When viewing a single comment thread, clicking "All Comments" doesn't remove the thread from url. So if I hit F5 after that, I'm back into viewing just a part of the thread.

With this change the thread param will be dropped upon clicking the button:

`/post/example.com/123?thread=0.456#789` => `/post/example.com/123`