### PR TITLE
Add support for embedding hardgif

### DIFF
--- a/src/lib/components/lemmy/post/helpers.ts
+++ b/src/lib/components/lemmy/post/helpers.ts
@@ -52,6 +52,14 @@ export const optimizeImageURL = (
   }
 }
 
+const HARDGIF_REGEX = /^(?:https?:\/\/)?(?:www\.)?(?:hardgif\.com\/(?:gif\/))(\w+)(#.*)?$/
+
+export const isHardgifLink = (url?: string): RegExpMatchArray | null => {
+  if (!url) return null
+
+  return url?.match?.(HARDGIF_REGEX)
+}
+
 const YOUTUBE_REGEX =
   /^(?:https?:\/\/)?(?:www\.|m\.)?(?:youtu\.be\/|youtube\.com\/(?:embed\/|shorts\/|live\/|v\/|watch\?v=|watch\?.+&v=))((\w|-){11})(?:\S+)?$/
 
@@ -65,13 +73,14 @@ export const postLink = (post: Post) =>
   `/post/${encodeURIComponent(instance.data)}/${post.id}`
 
 export type MediaType = 'video' | 'image' | 'iframe' | 'embed' | 'none'
-export type IframeType = 'youtube' | 'video' | 'none'
+export type IframeType = 'youtube' | 'hardgif' | 'video' | 'none'
 
 export const mediaType = (url?: string): MediaType => {
   if (url) {
     if (isImage(url)) return 'image'
     if (isVideo(url)) return 'iframe'
     if (isYoutubeLink(url)) return 'iframe'
+    if (isHardgifLink(url)) return 'iframe'
     if (canParseUrl(url)) return 'embed'
     return 'none'
   }
@@ -81,6 +90,7 @@ export const mediaType = (url?: string): MediaType => {
 export const iframeType = (url: string): IframeType => {
   if (isVideo(url)) return 'video'
   if (isYoutubeLink(url)) return 'youtube'
+  if (isHardgifLink(url)) return 'hardgif'
   return 'none'
 }
 

--- a/src/lib/components/lemmy/post/media/PostIframe.svelte
+++ b/src/lib/components/lemmy/post/media/PostIframe.svelte
@@ -1,4 +1,16 @@
 <script lang="ts" module>
+  function hardgifVideoId(url: string): string | null {
+    const regex =
+      /^(?:https?:\/\/)?(?:www\.)?(?:hardgif\.com\/(?:gif\/))(\w+)(#.*)?$/
+    const match = url.match(regex)
+
+    if (match && match[1]) {
+      return match[1]
+    }
+
+    return null
+  }
+
   const youtubeDomain = (place: 'youtube' | 'invidious' | 'piped') => {
     switch (place) {
       case 'youtube': {
@@ -53,6 +65,12 @@
       )}/embed/${videoID}?${url.searchParams.toString()}`
     }
 
+    if (type == 'hardgif') {
+      const videoID = hardgifVideoId(inputUrl)
+
+      return `https://hardgif.com/embedPlayer.php?post_id=${videoID}`
+    }
+
     return ''
   }
 
@@ -73,6 +91,12 @@
         return {
           icon: VideoCamera,
           text: 'Video',
+        }
+      }
+      case 'hardgif': {
+        return {
+          icon: VideoCamera,
+          text: 'Video Hardgif',
         }
       }
       default: {


### PR DESCRIPTION
Enabled embedding of hardgif. I've followed what you did with YouTube.

It may help to include the original link above or below the embed, as the page may include a link to the original content that it was created from.