### PR TITLE
fix: inbox route tabs highlight

### DIFF
--- a/src/lib/components/ui/layout/pages/Tabs.svelte
+++ b/src/lib/components/ui/layout/pages/Tabs.svelte
@@ -9,12 +9,6 @@
       name: string
     }[]
     currentRoute?: string | undefined
-    isSelected?: (
-      url: URL,
-      currentRoute: string | undefined,
-      route: string,
-      defaultRoute?: string,
-    ) => boolean
     buildUrl?: (currentRoute: string | undefined, href: string) => string
     defaultRoute?: string | undefined
     class?: string
@@ -24,13 +18,29 @@
   let {
     routes,
     currentRoute = undefined,
-    isSelected = (url, currentRoute, route) =>
-      (currentRoute ?? url.pathname) == route,
     buildUrl = (route, href) => href,
     defaultRoute = undefined,
     class: clazz = '',
     children,
   }: Props = $props()
+
+  function isSelected(
+    url: URL,
+    currentRoute: string | undefined,
+    route: string,
+    defaultRoute?: string,
+  ) {
+    if (route.startsWith('?')) {
+      const param = route.slice(1)
+      const key = param.split(/(?<=[=])/g)[0]
+      if (currentRoute?.includes(param)) {
+        return true
+      } else if (route == defaultRoute && !currentRoute?.includes(key)) {
+        return true
+      }
+    }
+    return (currentRoute ?? url.pathname) == route
+  }
 </script>
 
 <nav

--- a/src/routes/inbox/+page.svelte
+++ b/src/routes/inbox/+page.svelte
@@ -98,17 +98,12 @@ items-center px-2 w-max top-6 lg:top-22"
         },
       ]}
       currentRoute={page.url.search}
-      isSelected={(url, current, route, def) =>
-        page.url.search == route ||
-        (page.url.pathname == route && page.url.search == '') ||
-        page.url.searchParams.toString().includes(route.slice(1)) ||
-        (page.url.search == '' && route == def)}
-      class="overflow-auto"
       buildUrl={(route, href) =>
         href.includes('?')
           ? '?' + addSearchParam(page.url.searchParams, href).toString()
           : `${href}${page.url.search}`}
-      defaultRoute="?type=All"
+      defaultRoute="?type=all"
+      class="overflow-auto"
     />
     <Tabs
       routes={[
@@ -121,9 +116,7 @@ items-center px-2 w-max top-6 lg:top-22"
           name: $t('filter.unread'),
         },
       ]}
-      isSelected={(url, current, route, def) =>
-        page.url.searchParams.toString().includes(route.slice(1)) ||
-        (page.url.search == '' && route == def)}
+      currentRoute={page.url.search}
       buildUrl={(route, href) =>
         '?' + addSearchParam(page.url.searchParams, href).toString()}
       defaultRoute="?unreadOnly=true"


### PR DESCRIPTION
Closes #546 

This fixes highlighting of current tab in inbox. The tab will now properly check the contents of url search query, to decide whether to highlight itself or not. I checked other uses of the Tabs component as well, and it doesn't seem to break anything.

Moving the function from props may be unwanted, but the new logic should be robust.