### PR TITLE
feat/fix: add mismatching instance page

### DIFF
--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -286,6 +286,15 @@
             "commented": "Your comment was posted.",
             "loadComments": "Load comments"
         },
+        "postRedirect": {
+            "title": "Mismatching instance",
+            "description": "That link resolves to a post not on your account's instance, {{homeInstance}}.",
+            "actions": {
+                "back": "Go back",
+                "fetch": "Locate post on {{homeInstance}}",
+                "switch": "Switch to an account on {{destInstance}}"
+            }
+        },
         "inbox": {
             "title": "Inbox",
             "markAsRead": "Mark All Read",

--- a/src/routes/login/guest/+page.svelte
+++ b/src/routes/login/guest/+page.svelte
@@ -11,13 +11,15 @@
   import { goto } from '$app/navigation'
   import { t } from '$lib/translations'
   import Header from '$lib/components/ui/layout/pages/Header.svelte'
+  import { page } from '$app/state'
 
   interface Props {
     ref?: string
     children?: import('svelte').Snippet
   }
 
-  let { ref = '/', children }: Props = $props()
+  let { ref = page.url.searchParams.get('redirect') ?? '/', children }: Props =
+    $props()
 
   let form = $state({
     instance: '',

--- a/src/routes/post/[instance]/[id=integer]/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/+page.svelte
@@ -78,28 +78,6 @@
     })
   })
 
-  const fetchOnHome = async (jwt: string) => {
-    const id = toast({
-      content: $t('toast.fetchPostOnHome'),
-      loading: true,
-    })
-
-    try {
-      const res = await getClient().resolveObject({
-        q: data.post.value.post_view.post.ap_id,
-      })
-
-      if (res.post) {
-        removeToast(id)
-        goto(`/post/${instance.data}/${res.post.post.id}`, {}).then(() =>
-          removeToast(id),
-        )
-      }
-    } catch (err) {
-      removeToast(id)
-    }
-  }
-
   let commentsPage = 1
   let loading = $state(false)
 
@@ -117,10 +95,6 @@
     data.thread.value.singleThread = false
     commentsPage = 1
   }
-
-  let remoteView = $derived(
-    page.params.instance?.toLowerCase() != instance.data?.toLowerCase(),
-  )
 </script>
 
 <svelte:head>
@@ -164,44 +138,6 @@
 </svelte:head>
 
 <article class="flex flex-col gap-2">
-  {#if remoteView}
-    <div
-      class="sticky top-0 bg-slate-50 dark:bg-zinc-950 z-20
-      border-b dark:border-zinc-800 border-slate-300
-      -mx-4 -mt-4 md:-mt-6 md:-mx-6 sticky-header px-4 py-2
-      flex items-center gap-2 mb-4 h-12
-      "
-    >
-      <Popover openOnHover>
-        {#snippet target()}
-          <Icon
-            src={InformationCircle}
-            size="24"
-            solid
-            class="bg-slate-200 dark:bg-zinc-700 p-0.5 rounded-full text-primary-900 dark:text-primary-100"
-          />
-        {/snippet}
-        {$t('routes.post.instanceWarning')}
-      </Popover>
-      <span class="text-primary-900 dark:text-primary-100 font-bold">
-        {$t('routes.post.remoteView')}
-      </span>
-      {#if profile.data?.jwt}
-        <Button
-          class="ml-auto"
-          onclick={() => {
-            if (profile.data?.jwt) {
-              fetchOnHome(profile.data?.jwt)
-            }
-          }}
-        >
-          <Icon src={Home} mini size="16" />
-          {$t('routes.post.localView')}
-        </Button>
-      {/if}
-    </div>
-  {/if}
-
   <header class="flex flex-col gap-2">
     <div class="flex flex-row justify-between items-center gap-2 flex-wrap">
       <PostMeta

--- a/src/routes/post/[instance]/[id=integer]/confirm/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/confirm/+page.svelte
@@ -1,0 +1,107 @@
+<script lang="ts">
+  import { goto } from '$app/navigation'
+  import { resolveRoute } from '$app/paths'
+  import { page } from '$app/state'
+  import { profile, profileData } from '$lib/auth.svelte'
+  import Header from '$lib/components/ui/layout/pages/Header.svelte'
+  import ProfileButton from '$lib/components/ui/sidebar/ProfileButton.svelte'
+  import SidebarButton from '$lib/components/ui/sidebar/SidebarButton.svelte'
+  import { client } from '$lib/lemmy.svelte'
+  import { errorMessage } from '$lib/lemmy/error'
+  import { t } from '$lib/translations'
+  import { toast } from 'mono-svelte'
+  import Button from 'mono-svelte/button/Button.svelte'
+  import Material from 'mono-svelte/materials/Material.svelte'
+  import { Plus } from 'svelte-hero-icons'
+
+  let loading = $state(false)
+  const fetched = $state.snapshot(profile.data.instance)
+
+  async function fetchOnHome() {
+    loading = true
+    try {
+      const res = await client().resolveObject({
+        q: `https://${page.params.instance}/post/${page.params.id}`,
+      })
+
+      if (res.post) {
+        goto(
+          resolveRoute(`/post/[instance]/[id]`, {
+            instance: profile.data.instance,
+            id: res.post.post.id.toString(),
+          }),
+        )
+      }
+    } catch (err) {
+      toast({ content: errorMessage(err), type: 'error' })
+    }
+    loading = false
+  }
+</script>
+
+<div class="w-full h-full flex flex-col justify-center mx-auto max-w-xl gap-6">
+  <header class="space-y-1">
+    <div class="font-mono bg-zinc-950 rounded-sm p-0.5 px-1 w-max">
+      {page.params.instance}/post/{page.params.id}
+    </div>
+    <Header>
+      {$t('routes.postRedirect.title')}
+    </Header>
+    <p>
+      {$t('routes.postRedirect.description', {
+        // @ts-ignore
+        homeInstance: fetched,
+      })}
+    </p>
+  </header>
+  <div class="flex flex-row items-center gap-2 flex-wrap">
+    {#if profile.data.jwt}
+      <Button
+        {loading}
+        disabled={loading}
+        size="md"
+        rounding="pill"
+        color="primary"
+        onclick={fetchOnHome}
+      >
+        {$t('routes.postRedirect.actions.fetch', {
+          // @ts-ignore
+          homeInstance: fetched,
+        })}
+      </Button>
+    {/if}
+    <Button size="md" rounding="pill" onclick={() => history.back()}>
+      {$t('routes.postRedirect.actions.back')}
+    </Button>
+  </div>
+  {#if profileData.profiles}
+    {@const filtered = profileData.profiles.filter(
+      (i) => i.instance == page.params.instance,
+    )}
+    <div class="space-y-1">
+      <div class="font-medium text-sm">
+        {$t('routes.postRedirect.actions.switch', {
+          // @ts-ignore
+          destInstance: page.params.instance,
+        })}
+      </div>
+      <Material
+        color="uniform"
+        padding="sm"
+        rounding="2xl"
+        class="dark:bg-zinc-950 max-h-96 overflow-auto"
+      >
+        {#each filtered as profile, index}
+          <ProfileButton prof={profile} {index} />
+        {/each}
+        <SidebarButton
+          href="/accounts/login/guest?redirect={page.url}"
+          icon={Plus}
+          class="rounded-lg"
+        >
+          {$t('account.addGuest')}
+        </SidebarButton>
+      </Material>
+    </div>
+  {/if}
+</div>

--- a/src/routes/post/[instance]/[id=integer]/confirm/+page.ts
+++ b/src/routes/post/[instance]/[id=integer]/confirm/+page.ts
@@ -1,0 +1,7 @@
+import { profile } from '$lib/auth.svelte.js'
+import { redirect } from '@sveltejs/kit'
+
+export async function load({ params }) {
+  if (profile.data.instance == params.instance)
+    redirect(302, `/post/${params.instance}/${params.id}`)
+}


### PR DESCRIPTION
The way remote instance links are handled currently is a bit problematic, it just downloads the data from the external instance on your client, even if you don't want to.

This could lead to IP grabbers via making a post link like `https://phtn.app/post/grabify.link/123123123`

This commit adds a separate page, where absolutely no data is ever downloaded from an external instance unless you switch to an account with it.