### PR TITLE
fix: profile submissions broken

### DIFF
--- a/src/routes/profile/user/+page.svelte
+++ b/src/routes/profile/user/+page.svelte
@@ -14,8 +14,8 @@
         sort: data.sort,
         type: data.type,
       }),
-      person_view: data.user.person_view,
-      moderates: data.user.moderates,
+      person_view: {value: data.user.person_view},
+      moderates: {value: data.user.moderates},
     }}
   />
 {:else}

--- a/src/routes/profile/user/+page.ts
+++ b/src/routes/profile/user/+page.ts
@@ -4,8 +4,8 @@ import type { SortType } from 'lemmy-js-client'
 
 export async function load({ url, fetch, parent }) {
   const page = Number(url.searchParams.get('page')) || 1
-  const type: 'comments' | 'posts' | 'all' =
-    (url.searchParams.get('type') as 'comments' | 'posts' | 'all') || 'all'
+  const type: 'comments' | 'posts' =
+    (url.searchParams.get('type') as 'comments' | 'posts') || 'posts'
   const sort: SortType = (url.searchParams.get('sort') as SortType) || 'New'
 
   const { my_user } = await parent()

--- a/src/routes/u/[name]/+page.svelte
+++ b/src/routes/u/[name]/+page.svelte
@@ -343,9 +343,9 @@
       >
         {#key data.items}
           {#each data.items.value as item}
-            {#if isCommentView(item)}
+            {#if isCommentView(item) && data.filters.value.type == 'comments'}
               <CommentItem comment={item} />
-            {:else if !isCommentView(item)}
+            {:else if !isCommentView(item) && data.filters.value.type == 'posts'}
               <Post post={item} />
             {/if}
           {/each}

--- a/src/routes/u/[name]/+page.ts
+++ b/src/routes/u/[name]/+page.ts
@@ -1,7 +1,7 @@
 import { getClient } from '$lib/lemmy.svelte.js'
 import { getItemPublished } from '$lib/lemmy/item.js'
 import { ReactiveState } from '$lib/promise.svelte.js'
-import type { SortType } from 'lemmy-js-client'
+import type { CommentView, PostView, SortType } from 'lemmy-js-client'
 
 export async function load({ params, url, fetch }) {
   const page = Number(url.searchParams.get('page')) || 1
@@ -18,7 +18,8 @@ export async function load({ params, url, fetch }) {
     sort: sort,
   })
 
-  const items = type == 'posts' ? user.posts : user.comments
+  const items: (PostView | CommentView)[] =
+    type == 'posts' ? user.posts : user.comments
 
   return {
     filters: new ReactiveState({


### PR DESCRIPTION
Closes #555

A quick and dirty fix to make profile submissions page work again. 

**Changes:**

- Fix accessing ReactiveState (added `.value`)
- Removed `all` type from submissions page
- Items were inferred as `PostView[] | CommentView[]`, but `(PostView | CommentView)[]` was expected. Explicitly typed it as the latter.