### PR TITLE
ci: setup ci and linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+on:
+  - push
+  - pull_request
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: install
+        run: npm install
+      - name: deps
+        run: npm ci
+      - name: build
+        run: npm run build
+      - name: lint
+        run: npm run lint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Photon
 
-[![CI](https://github.com/sevonj/photon/actions/workflows/ci.yml/badge.svg)](https://github.com/sevonj/photon/actions/workflows/ci.yml)
+[![CI](https://github.com/xyphyn/photon/actions/workflows/ci.yml/badge.svg)](https://github.com/xyphyn/photon/actions/workflows/ci.yml)
 
 Photon is a Svelte-based opinionated Lemmy client designed for the best UI and UX. Every feature is carefully considered and placed.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Photon
 
+[![CI](https://github.com/sevonj/photon/actions/workflows/ci.yml/badge.svg)](https://github.com/sevonj/photon/actions/workflows/ci.yml)
+
 Photon is a Svelte-based opinionated Lemmy client designed for the best UI and UX. Every feature is carefully considered and placed.
 
 - `🌟` A stunning UI

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,39 @@
+import js from '@eslint/js';
+import { includeIgnoreFile } from '@eslint/compat';
+import svelte from 'eslint-plugin-svelte';
+import globals from 'globals';
+import { fileURLToPath } from 'node:url';
+import ts from 'typescript-eslint';
+import svelteConfig from './svelte.config.js';
+
+const gitignorePath = fileURLToPath(new URL('./.gitignore', import.meta.url));
+
+export default ts.config(
+	includeIgnoreFile(gitignorePath),
+	js.configs.recommended,
+	...ts.configs.recommended,
+	...svelte.configs.recommended,
+	{
+		languageOptions: {
+			globals: { ...globals.browser, ...globals.node }
+		},
+		rules: { // typescript-eslint strongly recommend that you do not use the no-undef lint rule on TypeScript projects.
+		// see: https://typescript-eslint.io/troubleshooting/faqs/eslint/#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors
+		"no-undef": 'off' }
+	},
+	{
+		files: [
+			'**/*.svelte',
+			'**/*.svelte.ts',
+			'**/*.svelte.js'
+		],
+		languageOptions: {
+			parserOptions: {
+				projectService: true,
+				extraFileExtensions: ['.svelte'],
+				parser: ts.parser,
+				svelteConfig
+			}
+		}
+	}
+);

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "devDependencies": {
     "@dicebear/core": "^8.0.1",
     "@dicebear/initials": "^8.0.1",
+    "@eslint/compat": "^1.2.9",
+    "@eslint/js": "^9.28.0",
     "@svelte-put/qr": "^2.0.0",
     "@sveltejs/adapter-auto": "^3.3.1",
     "@sveltejs/adapter-node": "^5.2.9",
@@ -14,6 +16,8 @@
     "@tailwindcss/postcss": "^4.1.8",
     "@types/nprogress": "^0.2.0",
     "@types/ua-parser-js": "^0.7.39",
+    "eslint": "^9.28.0",
+    "eslint-plugin-svelte": "^3.9.1",
     "jsdom": "^22.1.0",
     "lemmy-js-client": "^0.19.6-beta.1",
     "linkify-it": "^5.0.0",
@@ -36,6 +40,7 @@
     "tailwindcss": "^4.1.8",
     "tslib": "^2.4.1",
     "typescript": "^5.5.0",
+    "typescript-eslint": "^8.33.1",
     "ua-parser-js": "^1.0.38",
     "vite": "^5.4.14",
     "vitest": "^1.0.0"
@@ -54,7 +59,8 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "format": "prettier --write .",
-    "format:specific": "prettier --write"
+    "format:specific": "prettier --write",
+    "lint": "eslint ."
   },
   "type": "module",
   "dependencies": {


### PR DESCRIPTION
This PR is inspired by #555.

I always try to automatically enforce correctness wherever it's easy enough to do so, and I think you should too.

**Changes:**
- Added eslint & `npm run lint` command. It's setup the same as how Svelte template does it.
- Copied and adjusted my ci workflow from https://github.com/sevonj/yykaakoo-lemmy/

This will catch some "obvious" bugs, such as passing values of wrong type. 

**Notes:**

- There's some cleanup to be done before the the red badge becomes a meaningful indicator.
- I didn't mess with the readme beyond adding a badge, but you could also add something like this to the end:  
```md
## Development

### Continuous Integration

Pull requests are gatekept by [this workflow.](.github/workflows/ci.yml) It will check if the code

- builds (run `npm run build`)
- has linter warnings (run `npm run lint`)
<!-- - is formatted (run `npm run format`) -->
```