### PR TITLE
fix: /inbox/messages: show chats without response

### DIFF
--- a/src/routes/inbox/messages/+page.svelte
+++ b/src/routes/inbox/messages/+page.svelte
@@ -13,7 +13,7 @@
     user: Person
     message: {
       date: Date
-      last_sender: string
+      last_sender: number
       content: string
     }
   }
@@ -53,7 +53,7 @@
             : i.recipient,
         message: {
           date: publishedToDate(i.private_message.published),
-          last_sender: i.creator.name,
+          last_sender: i.creator.id,
           content: i.private_message.content,
         },
       }))
@@ -79,7 +79,7 @@
     {#each previews as preview, index (preview)}
       <a
         href="/inbox/messages/{preview.user.id}"
-        class="flex flex-row gap-2 py-3 -mx-4 px-4 sm:-mx-6 sm:px-6 w-full min-w-0
+        class="flex flex-row gap-2 py-3 -mx-4 sm:-mx-6 px-4 sm:px-6 min-w-0
         hover:bg-slate-100 dark:hover:bg-zinc-900 transition-colors"
         in:fly|global={{
           duration: 700,
@@ -96,7 +96,10 @@
             bg-linear-to-r from-slate-700 via-slate-700 to-slate-700/0 dark:from-zinc-300 dark:via-zinc-300 dark:to-zinc-300/0
             text-transparent bg-clip-text"
           >
-            {preview.message.last_sender}: {preview.message.content}
+            {#if preview.message.last_sender == profile.data.user?.local_user_view.person.id}
+              {profile.data.user?.local_user_view.person.name}:
+            {/if}
+            {preview.message.content}
           </div>
         </div>
       </a>


### PR DESCRIPTION
Closes #441 

**Changes:**
- Message list now checks both _creator_ and _recipient_ to determine the other party, instead of just _creator._
- Message list shows the username of last sender.

![Screenshot From 2025-06-14 14-01-26](https://github.com/user-attachments/assets/c39c0721-e9ac-4580-b08c-6e2dd9d0f537)
