### PR TITLE
fix: markdown blockquote paragraph gap

### DIFF
--- a/src/lib/components/markdown/renderers/MdQuote.svelte
+++ b/src/lib/components/markdown/renderers/MdQuote.svelte
@@ -8,6 +8,8 @@
   let { children } = $props()
 </script>
 
-<blockquote class="border-l-2 dark:border-zinc-700 border-slate-300 p-1 px-3">
+<blockquote
+  class="flex flex-col gap-2 border-l-2 dark:border-zinc-700 border-slate-300 p-1 px-3"
+>
   {@render children?.()}
 </blockquote>


### PR DESCRIPTION
Closes #532 

**Changes:**
- Blockquote now has the same flex & gap rules as the root markdown container div


Before / After:

![image](https://github.com/user-attachments/assets/396d1dcb-f39a-40e1-b22e-e1110a08602e)
