### PR TITLE
fix: re: external link on comment should open in new tab

### DIFF
--- a/src/lib/components/markdown/renderers/MdLink.svelte
+++ b/src/lib/components/markdown/renderers/MdLink.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { photonify } from './plugins.js'
+  import { page } from '$app/state'
 
   interface Props {
     href?: string
@@ -18,10 +19,13 @@
   }
 
   let photonified = $derived(photonify(href))
+
+  const isInternalLink = parseURL(href)?.host === page.url.host;
 </script>
 
 <a
   href={photonified ?? href}
+  target={photonified || isInternalLink ? undefined : "_blank"}
   {title}
   class="hover:underline text-sky-600 dark:text-sky-500"
 >


### PR DESCRIPTION
Retry #615 after reverted in #619

Added checked if the href provided has the same host with current url

Also use undefined to remove the `target` attributes instead of setting it as `"_self"` when it is an internal link