### PR TITLE
CI: Fix TS linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,10 +1,10 @@
-name: Lint
+name: Check & Lint
 on:
   - pull_request
 jobs:
   lint:
     runs-on: ubuntu-latest
-    name: Lint
+    name: Check & Lint
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -14,5 +14,7 @@ jobs:
         run: npm install
       - name: deps
         run: npm ci
+      - name: check
+        run: npm run check
       - name: lint
         run: npm run lint


### PR DESCRIPTION
Apparently eslint doesn't care about most basic typescript errors.

Added a new CI step that runs svelte-check, which already existed in the project, but was unused.

The check will now fail on things like this:

<img width="1121" height="164" alt="Screenshot From 2025-09-22 13-37-46" src="https://github.com/user-attachments/assets/8979bf3d-a243-466d-a0b4-9726e5793178" />