### PR TITLE
impr: rewrite common shell components to use tailwind-bounded but vanilla CSS

### DIFF
--- a/src/lib/feature/post/PostLink.svelte
+++ b/src/lib/feature/post/PostLink.svelte
@@ -32,37 +32,25 @@
   <Material
     color="uniform"
     class={[
-      'flex flex-col-reverse sm:flex-row overflow-hidden gap-4 z-0 relative',
-      'dark:bg-zinc-950 hover:bg-slate-50 hover:dark:bg-zinc-900 transition-colors',
-      'group/link',
+      'post-link group/link hover:bg-slate-50 hover:dark:bg-zinc-900 transition-colors',
     ]}
     rounding="2xl"
     element="a"
-    padding="sm"
+    padding="none"
     href={url}
     target="_blank"
     rel="noopener"
   >
-    {#if thumbnail_url}
-      <img
-        src={optimizeImageURL(thumbnail_url, 32)}
-        alt=""
-        class="-z-10 absolute w-full object-cover h-full opacity-5 brightness-150
-        dark:brightness-70 dark:opacity-10 blur-2xl -inset-px"
-      />
-    {/if}
-    <div class={['flex flex-col gap-1 p-2', thumbnail_url && '-mt-2 sm:mt-0']}>
+    <div class={['post-link-url', thumbnail_url && '-mt-2 sm:mt-0']}>
       {#if richURL}
-        <div
-          class="text-slate-600 dark:text-zinc-400 inline-flex items-center gap-1 text-xs font-medium"
-        >
+        <div class="link-hostname">
           {richURL.hostname}
         </div>
       {/if}
-      <p class="font-medium text-base">{embed_title}</p>
+      <p class="post-link-title">{embed_title}</p>
     </div>
     {#if thumbnail_url}
-      <picture class="mb-auto sm:ml-auto shrink-0 sm:w-1/3 sm:max-w-60">
+      <picture class="post-link-image">
         {#each ['webp'] as format}
           <source
             srcset="{optimizeImageURL(
@@ -80,7 +68,7 @@
         {/each}
         <img
           src={optimizeImageURL(thumbnail_url, -1)}
-          class="object-cover w-full sm:max-w-96 h-32 sm:min-h-16 bg-slate-200 dark:bg-zinc-800 rounded-xl"
+          class=""
           width={600}
           height={400}
           alt=""
@@ -94,18 +82,14 @@
     href={url}
     target="_blank"
     rel="noopener noreferrer"
-    class="flex flex-row text-slate-900 dark:text-zinc-400 items-center overflow-hidden group/link hover:underline space-x-1 my-1"
+    class="post-link-compact"
   >
     <Icon src={Link} size="16" micro class="shrink-0" />
     {#if richURL}
-      <div
-        class="flex max-w-full overflow-hidden font-medium self-start justify-self-start w-max text-sm"
-      >
+      <div class="post-link-url">
         {richURL.hostname}
         {#if richURL.pathname != '/'}
-          <span
-            class="text-slate-500 dark:text-zinc-500 whitespace-nowrap font-normal group-hover/link:opacity-100 opacity-0 transition-opacity duration-100"
-          >
+          <span class="post-link-extended">
             {richURL.pathname}
           </span>
         {/if}
@@ -115,3 +99,130 @@
     {/if}
   </a>
 {/if}
+
+<style>
+  @reference '../../../app.css';
+  :global(.post-link) {
+    display: flex;
+    flex-direction: column-reverse;
+    overflow: hidden;
+    gap: calc(var(--spacing) * 4);
+    position: relative;
+    @variant sm {
+      flex-direction: row;
+    }
+
+    .post-link-url {
+      display: flex;
+      flex-direction: column;
+      gap: var(--spacing);
+      padding: calc(var(--spacing) * 4);
+
+      .link-hostname {
+        color: var(--color-slate-600);
+        display: inline-flex;
+        align-items: center;
+        gap: var(--spacing);
+        font-size: var(--text-xs);
+        font-weight: var(--font-weight-medium);
+
+        @variant dark {
+          color: var(--color-zinc-400);
+        }
+      }
+    }
+
+    .post-link-title {
+      font-weight: var(--font-weight-medium);
+      font-size: var(--text-base);
+      letter-spacing: var(--tracking-tight);
+      max-width: calc(var(--spacing) * 108);
+    }
+
+    .post-link-image {
+      flex-shrink: 0;
+      margin-bottom: auto;
+
+      @variant sm {
+        margin-left: auto;
+      }
+
+      @variant max-md {
+        mask-image: linear-gradient(to bottom, black, transparent);
+      }
+
+      @variant sm {
+        width: 33%;
+        max-width: calc(var(--spacing) * 90);
+      }
+
+      @variant md {
+        mask-image: linear-gradient(to left, black, black, transparent);
+      }
+
+      img {
+        object-fit: cover;
+        width: 100%;
+        height: calc(var(--spacing) * 40);
+        background-color: var(--color-slate-200);
+
+        @variant sm {
+          max-width: calc(var(--spacing) * 96);
+          min-height: calc(var(--spacing) * 16);
+        }
+
+        @variant dark {
+          background-color: var(--color-zinc-800);
+        }
+      }
+    }
+  }
+
+  .post-link-compact {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    overflow: hidden;
+    margin: var(--spacing) 0;
+    gap: var(--spacing);
+    color: var(--color-slate-700);
+
+    @variant dark {
+      color: var(--color-zinc-400);
+    }
+
+    @variant hover {
+      text-decoration-line: underline;
+    }
+
+    .post-link-url {
+      display: flex;
+      flex-direction: row;
+      gap: 0;
+      max-width: 100%;
+      overflow: hidden;
+      font-weight: var(--font-medium);
+      align-self: flex-start;
+      justify-self: start;
+      width: max-content;
+      font-size: var(--text-sm);
+    }
+
+    .post-link-extended {
+      color: var(--color-slate-500);
+      white-space: nowrap;
+      opacity: 0;
+      transition: opacity linear 100ms;
+
+      @variant dark {
+        color: var(--color-zinc-500);
+      }
+    }
+
+    @variant hover {
+      .post-link-extended {
+        opacity: 1;
+      }
+    }
+  }
+</style>

--- a/src/lib/feature/post/PostMeta.svelte
+++ b/src/lib/feature/post/PostMeta.svelte
@@ -360,7 +360,7 @@
   {@const useAttachedUrl = settings.posts.titleOpensUrl && postUrl}
   <h3
     class={[
-      'font-medium max-sm:mt-0!',
+      'font-medium max-sm:mt-0! tracking-tight',
       titleClass,
       settings.markReadPosts && read && 'text-slate-600 dark:text-zinc-400',
       view == 'compact' ? 'text-base' : 'text-lg',

--- a/src/lib/ui/generic/Fixate.svelte
+++ b/src/lib/ui/generic/Fixate.svelte
@@ -14,6 +14,11 @@
   let { placement, children }: Props = $props()
 </script>
 
-<div class={['sticky z-30 mb-0', placements[placement]]}>
+<div
+  class={[
+    'sticky z-30 mb-0 pointer-events-none *:pointer-events-auto',
+    placements[placement],
+  ]}
+>
   {@render children?.()}
 </div>

--- a/src/lib/ui/layout/Shell.svelte
+++ b/src/lib/ui/layout/Shell.svelte
@@ -11,10 +11,10 @@
 
   interface Props extends HTMLAttributes<HTMLDivElement> {
     children?: Snippet
-    navbar?: Snippet<[{ class: ClassValue; style: string }]>
-    sidebar?: Snippet<[{ class: ClassValue; style: string }]>
-    main?: Snippet<[{ class: ClassValue; style: string }]>
-    suffix?: Snippet<[{ class: ClassValue; style: string }]>
+    navbar?: Snippet<[{ class: ClassValue; style?: string }]>
+    sidebar?: Snippet<[{ class: ClassValue; style?: string }]>
+    main?: Snippet<[{ class: ClassValue; style?: string }]>
+    suffix?: Snippet<[{ class: ClassValue; style?: string }]>
   }
 
   let { children, navbar, sidebar, main, suffix }: Props = $props()
@@ -38,12 +38,7 @@
 {@render children?.()}
 <div class="min-h-screen flex flex-col">
   <div
-    class={[
-      'fixed md:sticky bottom-0 md:top-0',
-      !dockVisible && 'max-md:-bottom-24',
-      'w-full z-50 pointer-events-none',
-    ]}
-    style="transition: bottom .4s cubic-bezier(0.075, 0.82, 0.165, 1);"
+    class={['shell-navbar-holder', !dockVisible && 'max-md:-bottom-24']}
     aria-hidden="true"
   >
     <div class="md:hidden flex justify-between" dir="ltr">
@@ -55,32 +50,65 @@
       />
     </div>
     {@render navbar?.({
-      class: [
-        'md:bg-slate-100/70 md:dark:bg-zinc-950/90 border-slate-200/50 dark:border-zinc-900',
-        'bg-slate-100 dark:bg-zinc-950',
-        'pointer-events-auto backdrop-blur-xl border border-t-0 md:border-x-0',
-      ],
-      style: '',
+      class: ['shell-navbar'],
     })}
   </div>
-  <div class={['content flex-1', settings.newWidth && 'limit-width']}>
+  <div class={['shell-content flex-1', settings.newWidth && 'limit-width']}>
     {@render sidebar?.({
-      class: `hidden md:flex sticky top-0 lg:top-16 left-0 max-h-[calc(100vh-4rem)] bg-slate-100 dark:bg-zinc-950 z-40`,
-      style: 'grid-area: sidebar; width: 100% !important;',
+      class: `shell-aside shell-sidebar`,
     })}
     {@render main?.({
-      class: `w-full bg-slate-50 dark:bg-zinc-925 max-lg:pb-22 justify-self-center border-x border-slate-200 dark:border-zinc-900 pb-3 lg:pb-6`,
-      style: 'grid-area: main',
+      class: `shell-main`,
     })}
     {@render suffix?.({
-      class: `max-lg:hidden flex w-full sticky top-0 lg:top-16 left-0 max-h-[calc(100vh-4rem)] overflow-auto bg-slate-100 dark:bg-zinc-950 z-40`,
-      style: 'grid-area: suffix;',
+      class: `shell-aside shell-suffix`,
     })}
   </div>
 </div>
 
 <style>
-  .content {
+  @reference '../../../app.css';
+
+  .shell-navbar-holder {
+    position: fixed;
+    bottom: 0;
+    z-index: 50;
+    pointer-events: none;
+    width: 100%;
+    transition: bottom 0.4s cubic-bezier(0.075, 0.82, 0.165, 1);
+
+    @variant md {
+      position: sticky;
+      top: 0;
+    }
+
+    :global {
+      .shell-navbar {
+        pointer-events: auto;
+        backdrop-filter: blur(var(--blur-xl));
+        border-width: 1px;
+        border-color: var(--color-slate-200);
+        border-top: none;
+        background-color: var(--color-slate-100);
+
+        @variant md {
+          border-left: none;
+          border-right: none;
+          background-color: --alpha(var(--color-slate-100) / 70%);
+        }
+
+        @variant dark {
+          background-color: var(--color-zinc-950);
+          border-color: var(--color-zinc-900);
+          @variant md {
+            background-color: --alpha(var(--color-zinc-950) / 70%);
+          }
+        }
+      }
+    }
+  }
+
+  .shell-content {
     width: 100%;
     display: grid;
     height: 100%;
@@ -92,12 +120,12 @@
     justify-items: start;
   }
 
-  .content.limit-width {
+  .shell-content.limit-width {
     max-width: 100rem;
   }
 
   @media (min-width: 48rem) {
-    .content {
+    .shell-content {
       grid-template-columns: 16rem 1fr;
       justify-items: end start;
       grid-template-areas: 'sidebar main';
@@ -105,15 +133,72 @@
   }
 
   @media (min-width: 64rem) {
-    .content {
+    .shell-content {
       grid-template-columns: 20% 60% 20%;
       justify-items: end center start;
       grid-template-areas: 'sidebar main suffix';
     }
 
-    .content.limit-width {
+    .shell-content.limit-width {
       width: 100%;
       grid-template-columns: 2fr 5fr 2fr;
+    }
+  }
+
+  .shell-content {
+    :global {
+      .shell-main {
+        width: 100%;
+        grid-area: main;
+        background-color: var(--color-slate-50);
+        border-left: 1px solid var(--color-slate-200);
+        border-right: 1px solid var(--color-slate-200);
+        padding-bottom: calc(var(--spacing) * 22);
+        z-index: 0;
+
+        @variant dark {
+          background-color: var(--color-zinc-925);
+          border-left: 1px solid var(--color-zinc-900);
+          border-right: 1px solid var(--color-zinc-900);
+        }
+
+        @variant md {
+          padding-bottom: calc(var(--spacing) * 6);
+        }
+      }
+
+      .shell-aside {
+        display: none;
+        position: sticky;
+        top: 0;
+        left: 0;
+        background-color: var(--color-slate-100);
+        z-index: 40;
+        width: 100%;
+
+        @variant dark {
+          background-color: var(--color-zinc-950);
+        }
+      }
+
+      .shell-sidebar {
+        grid-area: sidebar;
+        width: 100% !important;
+        @variant md {
+          display: flex;
+          top: calc(var(--spacing) * 16);
+          max-height: calc(100vh - 4rem);
+        }
+      }
+
+      .shell-suffix {
+        grid-area: suffix;
+        @variant lg {
+          display: flex;
+          top: calc(var(--spacing) * 16);
+          max-height: calc(100vh - 4rem);
+        }
+      }
     }
   }
 </style>

--- a/src/lib/ui/navbar/Navbar.svelte
+++ b/src/lib/ui/navbar/Navbar.svelte
@@ -30,16 +30,7 @@
 </script>
 
 <CommandsWrapper bind:open={promptOpen} />
-<nav
-  class={[
-    'w-full mx-auto z-50',
-    'md:gap-5 gap-2 flex flex-row items-center justify-evenly p-2 px-8 md:px-2',
-    'box-border p-0.5 duration-150 @container *:max-md:flex-1',
-    clazz,
-  ]}
-  {style}
-  data-sveltekit-preload-data
->
+<nav class={['navbar @container', clazz]} {style} data-sveltekit-preload-data>
   <NavButton
     oncontextmenu={(e: Event) => {
       e.preventDefault()
@@ -166,3 +157,30 @@
     {/snippet}
   </Menu>
 </nav>
+
+<style>
+  @reference '../../../app.css';
+
+  .navbar {
+    width: 100%;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-evenly;
+    padding: calc(var(--spacing) * 2);
+    box-sizing: border-box;
+
+    @variant max-md {
+      padding-left: calc(var(--spacing) * 8);
+      padding-right: calc(var(--spacing) * 8);
+
+      & > :global(*) {
+        flex: 1;
+      }
+    }
+
+    @variant md {
+      gap: calc(var(--spacing) * 6);
+    }
+  }
+</style>

--- a/src/lib/ui/shared/materials/Material.svelte
+++ b/src/lib/ui/shared/materials/Material.svelte
@@ -16,7 +16,7 @@
   }
 
   const paddingClass = {
-    none: 'p-0',
+    none: '',
     sm: 'p-2',
     md: 'p-4',
     lg: 'p-5',

--- a/src/lib/ui/shared/materials/Material.svelte
+++ b/src/lib/ui/shared/materials/Material.svelte
@@ -34,14 +34,10 @@
   }
 
   const colorClass = {
-    default:
-      'bg-white dark:bg-zinc-900 border border-slate-200 dark:border-zinc-800 border-b-slate-300 dark:border-t-zinc-700',
-    distinct:
-      'bg-white dark:bg-zinc-925 border border-slate-200 dark:border-zinc-900 border-b-slate-300 dark:border-t-zinc-800',
-    transparent:
-      'border border-slate-200 dark:border-zinc-900 border-b-slate-300 dark:border-t-zinc-800',
-    uniform:
-      'bg-white dark:bg-zinc-950 border border-slate-200 dark:border-zinc-900',
+    default: 'material-default',
+    distinct: 'material-distinct',
+    transparent: 'material-transparent',
+    uniform: 'material-uniform',
     none: '',
   }
 
@@ -82,3 +78,64 @@
 >
   {@render children?.()}
 </svelte:element>
+
+<style>
+  @reference '../../../../app.css';
+
+  .material-default {
+    background-color: white;
+    border-width: 1px;
+    border-color: var(--color-slate-200);
+
+    @variant not-dark {
+      border-bottom-color: var(--color-slate-300);
+    }
+
+    @variant dark {
+      background-color: var(--color-zinc-900);
+      border-color: var(--color-zinc-800);
+      border-top-color: var(--color-zinc-700);
+    }
+  }
+
+  .material-distinct {
+    background-color: white;
+    border-width: 1px;
+    border-color: var(--color-slate-200);
+
+    @variant not-dark {
+      border-bottom-color: var(--color-slate-300);
+    }
+
+    @variant dark {
+      background-color: var(--color-zinc-925);
+      border-color: var(--color-zinc-800);
+      border-top-color: var(--color-zinc-700);
+    }
+  }
+
+  .material-transparent {
+    border-width: 1px;
+    border-color: var(--color-slate-200);
+
+    @variant not-dark {
+      border-bottom-color: var(--color-slate-300);
+    }
+
+    @variant dark {
+      border-color: var(--color-zinc-900);
+      border-top-color: var(--color-zinc-800);
+    }
+  }
+
+  .material-uniform {
+    background-color: white;
+    border-width: 1px;
+    border-color: var(--color-slate-200);
+
+    @variant dark {
+      background-color: var(--color-zinc-950);
+      border-color: var(--color-zinc-900);
+    }
+  }
+</style>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -92,7 +92,6 @@
     this={settings.infiniteScroll && !settings.posts.noVirtualize
       ? 'noscript'
       : 'div'}
-    class="mt-auto flex flex-col"
   >
     <Pageination
       cursor={{ next: feed.next_page }}

--- a/src/routes/post/[instance]/[id=integer]/+page.svelte
+++ b/src/routes/post/[instance]/[id=integer]/+page.svelte
@@ -165,8 +165,8 @@
         tags={tags.tags}
       />
     </div>
-    <h1 class="font-medium text-xl leading-5">
-      <Markdown source={tags.title ?? data.data.value.post.post.name} />
+    <h1 class="font-medium font-display text-xl leading-5 tracking-tight">
+      <Markdown inline source={tags.title ?? data.data.value.post.post.name} />
     </h1>
   </header>
   <PostMedia


### PR DESCRIPTION
I get the benefits of tailwind's nice `@variant` tools and their styling variables, while decreasing the javascript bundle and complexity of the DOM.