### PR TITLE
feat: collapse less common time range sort options under "More" menu

### DIFF
--- a/src/lib/app/i18n/en.json
+++ b/src/lib/app/i18n/en.json
@@ -83,16 +83,16 @@
                 "label": "Top",
                 "time": {
                     "label": "Time",
-                    "all": "All",
-                    "9months": "9 Months",
-                    "6months": "6 Months",
-                    "3months": "3 Months",
-                    "month": "Month",
-                    "week": "Week",
-                    "day": "Day",
-                    "12hours": "12 Hours",
-                    "6hours": "6 Hours",
-                    "hour": "Hour"
+                    "all": "All time",
+                    "9months": "Past 9 months",
+                    "6months": "Past 6 months",
+                    "3months": "Past 3 months",
+                    "month": "Past month",
+                    "week": "Past week",
+                    "day": "Past day",
+                    "12hours": "Past 12 hours",
+                    "6hours": "Past 6 hours",
+                    "hour": "Past hour"
                 }
             },
             "new": "New",

--- a/src/lib/feature/filter/Sort.svelte
+++ b/src/lib/feature/filter/Sort.svelte
@@ -39,6 +39,10 @@
   }: Props = $props()
 
   let sort: string = $state(selected?.startsWith('Top') ? 'TopAll' : selected)
+
+  const moreTimeRanges = ['TopNineMonths', 'TopSixMonths', 'TopThreeMonths', 'TopTwelveHour', 'TopSixHour', 'TopHour']
+  let showMoreTimeRanges: boolean = $state(moreTimeRanges.includes(selected))
+
   const setSelected = () => (selected = sort)
 </script>
 
@@ -103,17 +107,8 @@
           {$t('filter.sort.top.time.label')}
         </span>
       {/snippet}
-      <Option value="TopAll" icon={PlusCircle}>
+      <Option value="TopAll" icon={Trophy}>
         {$t('filter.sort.top.time.all')}
-      </Option>
-      <Option value="TopNineMonths" icon={Calendar}>
-        {$t('filter.sort.top.time.9months')}
-      </Option>
-      <Option value="TopSixMonths" icon={Calendar}>
-        {$t('filter.sort.top.time.6months')}
-      </Option>
-      <Option value="TopThreeMonths" icon={Calendar}>
-        {$t('filter.sort.top.time.3months')}
       </Option>
       <Option value="TopMonth" icon={CalendarDays}>
         {$t('filter.sort.top.time.month')}
@@ -124,15 +119,35 @@
       <Option value="TopDay" icon={Sun}>
         {$t('filter.sort.top.time.day')}
       </Option>
-      <Option value="TopTwelveHour" icon={Clock}>
-        {$t('filter.sort.top.time.12hours')}
-      </Option>
-      <Option value="TopSixHour" icon={Clock}>
-        {$t('filter.sort.top.time.6hours')}
-      </Option>
-      <Option value="TopHour" icon={Clock}>
-        {$t('filter.sort.top.time.hour')}
-      </Option>
+      {#if !showMoreTimeRanges}
+        <button
+          type="button"
+          class="px-4 py-2 text-left text-sm hover:bg-slate-100 dark:hover:bg-zinc-800 cursor-pointer border-t border-slate-200 dark:border-zinc-700"
+          onclick={() => (showMoreTimeRanges = true)}
+        >
+          <span class="opacity-60">More...</span>
+        </button>
+      {/if}
+      {#if showMoreTimeRanges}
+        <Option value="TopNineMonths" icon={Calendar}>
+          {$t('filter.sort.top.time.9months')}
+        </Option>
+        <Option value="TopSixMonths" icon={Calendar}>
+          {$t('filter.sort.top.time.6months')}
+        </Option>
+        <Option value="TopThreeMonths" icon={Calendar}>
+          {$t('filter.sort.top.time.3months')}
+        </Option>
+        <Option value="TopTwelveHour" icon={Clock}>
+          {$t('filter.sort.top.time.12hours')}
+        </Option>
+        <Option value="TopSixHour" icon={Clock}>
+          {$t('filter.sort.top.time.6hours')}
+        </Option>
+        <Option value="TopHour" icon={Clock}>
+          {$t('filter.sort.top.time.hour')}
+        </Option>
+      {/if}
     </Select>
   {/if}
 </div>


### PR DESCRIPTION
- Reorganized top sort time ranges to show main options first (All time, Past month, Past week, Past day)
- Added collapsible "More..." section for less common time ranges (9 months, 6 months, 3 months, 12 hours, 6 hours, hour)
- Updated i18n translations to use more user-friendly labels ("All time", "Past week", "Past month", etc.)
- "More" section auto-expands when a collapsed option is currently selected