### PR TITLE
fix: make sidebar community icons square with rounded-lg

### DIFF
--- a/src/lib/ui/generic/ItemList.svelte
+++ b/src/lib/ui/generic/ItemList.svelte
@@ -30,6 +30,7 @@
           alt={item.name}
           title={item.name}
           width={24}
+          circle={false}
         />
       </div>
       <div class="flex flex-col max-w-full break-words">


### PR DESCRIPTION
Community icons in the sidebar ItemList were circular due to the Avatar component defaulting to circle={true}. This change adds circle={false} to match the border-radius used everywhere else (e.g., PostMeta).