### PR TITLE
fix: Missing escaped text

### DIFF
--- a/src/lib/app/markdown/Markdown.svelte
+++ b/src/lib/app/markdown/Markdown.svelte
@@ -95,6 +95,7 @@
     space: MdParagraph,
     list_item: MdListItem,
     text: MdText,
+    escape: MdText,
     em: MdEm,
     strong: MdStrong,
     del: MdDel,


### PR DESCRIPTION
- Closes #705 

<img width="469" height="307" alt="image" src="https://github.com/user-attachments/assets/279491a1-2b70-4a92-a297-70fbe81b5dd0" />
