### PR TITLE
PieFed starts pagination of posts/list from 1

### DIFF
--- a/src/lib/ui/layout/Pageination.svelte
+++ b/src/lib/ui/layout/Pageination.svelte
@@ -18,7 +18,7 @@
   }
 
   let {
-    page = $bindable(0),
+    page = $bindable(1),
     cursor = undefined,
     hasMore = true,
     children,


### PR DESCRIPTION
When loading the home page, Photon makes a request like this: `/api/alpha/post/list?sort=New&type_=All&limit=20&show_hidden=false&page=0`

It seems like changing the default value from 0 to 1 would fix this but I lack the necessary JS skill and experience of your codebase to know for sure. Please confirm.