### PR TITLE
fix image viewer to fit page and add zoom/pan

### DIFF
--- a/src/lib/feature/post/actions/PostActions.svelte
+++ b/src/lib/feature/post/actions/PostActions.svelte
@@ -33,7 +33,7 @@
     ShieldCheck,
   } from 'svelte-hero-icons/dist'
   import { PostVote } from '..'
-  import { PostFormState } from '../form/postform.svelte'
+  import { PostFormState } from '../form/postform.svelte.js'
   import { postLink } from '../helpers'
 
   let saving = $state(false)

--- a/src/lib/feature/post/actions/PostActionsMenu.svelte
+++ b/src/lib/feature/post/actions/PostActionsMenu.svelte
@@ -16,7 +16,7 @@
     Trash,
     XMark,
   } from 'svelte-hero-icons/dist'
-  import { type PostFormInit } from '../form/postform.svelte'
+  import { type PostFormInit } from '../form/postform.svelte.js'
   import { hidePost } from '../helpers'
 
   interface Props {

--- a/src/lib/feature/post/form/PostForm.svelte
+++ b/src/lib/feature/post/form/PostForm.svelte
@@ -47,7 +47,7 @@
     Trash,
     XMark,
   } from 'svelte-hero-icons/dist'
-  import { autofillPost, PostFormState } from './postform.svelte'
+  import { autofillPost, PostFormState } from './postform.svelte.js'
 
   interface Props {
     editPost?: number

--- a/src/lib/ui/generic/ExpandableImage.svelte
+++ b/src/lib/ui/generic/ExpandableImage.svelte
@@ -3,9 +3,14 @@
   import { page } from '$app/state'
   import { t } from '$lib/app/i18n'
   import { Button, Material, toast } from 'mono-svelte'
-  import { Share, XMark } from 'svelte-hero-icons/dist'
+  import {
+    MagnifyingGlassMinus,
+    MagnifyingGlassPlus,
+    Share,
+    XMark,
+  } from 'svelte-hero-icons/dist'
   import { backOut } from 'svelte/easing'
-  import { fade, scale } from 'svelte/transition'
+  import { fade, scale as scaleTransition } from 'svelte/transition'
   import { trapFocus } from 'trap-focus-svelte'
 
   export function showImage(url: string) {
@@ -24,30 +29,165 @@
   }
 
   let { alt = '' }: Props = $props()
+
+  const MIN_ZOOM = 1
+  const MAX_ZOOM = 8
+  const ZOOM_STEP = 1.5
+
+  let zoom = $state(1)
+  let translateX = $state(0)
+  let translateY = $state(0)
+  let dragging = $state(false)
+  let dragStartX = 0
+  let dragStartY = 0
+  let originX = 0
+  let originY = 0
+  let pinchStartDistance = 0
+  let pinchStartZoom = 1
+
+  function resetView() {
+    zoom = 1
+    translateX = 0
+    translateY = 0
+  }
+
+  function clampZoom(value: number) {
+    return Math.min(Math.max(value, MIN_ZOOM), MAX_ZOOM)
+  }
+
+  function setZoom(next: number) {
+    const newZoom = clampZoom(next)
+    if (newZoom === 1) {
+      translateX = 0
+      translateY = 0
+    }
+    zoom = newZoom
+  }
+
+  function zoomIn() {
+    setZoom(zoom * ZOOM_STEP)
+  }
+
+  function zoomOut() {
+    setZoom(zoom / ZOOM_STEP)
+  }
+
+  function handleWheel(e: WheelEvent) {
+    e.preventDefault()
+    const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
+    setZoom(zoom * factor)
+  }
+
+  function handlePointerDown(e: PointerEvent) {
+    if (zoom <= 1) return
+    dragging = true
+    dragStartX = e.clientX
+    dragStartY = e.clientY
+    originX = translateX
+    originY = translateY
+    ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
+  }
+
+  function handlePointerMove(e: PointerEvent) {
+    if (!dragging) return
+    translateX = originX + (e.clientX - dragStartX)
+    translateY = originY + (e.clientY - dragStartY)
+  }
+
+  function handlePointerUp(e: PointerEvent) {
+    if (!dragging) return
+    dragging = false
+    ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
+  }
+
+  function handleTouchStart(e: TouchEvent) {
+    if (e.touches.length === 2) {
+      e.preventDefault()
+      const dx = e.touches[0].clientX - e.touches[1].clientX
+      const dy = e.touches[0].clientY - e.touches[1].clientY
+      pinchStartDistance = Math.hypot(dx, dy)
+      pinchStartZoom = zoom
+    }
+  }
+
+  function handleTouchMove(e: TouchEvent) {
+    if (e.touches.length === 2 && pinchStartDistance > 0) {
+      e.preventDefault()
+      const dx = e.touches[0].clientX - e.touches[1].clientX
+      const dy = e.touches[0].clientY - e.touches[1].clientY
+      const distance = Math.hypot(dx, dy)
+      setZoom((distance / pinchStartDistance) * pinchStartZoom)
+    }
+  }
+
+  function handleTouchEnd(e: TouchEvent) {
+    if (e.touches.length < 2) pinchStartDistance = 0
+  }
+
+  function handleBackgroundClick() {
+    if (zoom > 1) {
+      resetView()
+      return
+    }
+    history.back()
+  }
+
+  $effect(() => {
+    if (!page.state.openImage) resetView()
+  })
 </script>
 
 {#if page.state.openImage || '' != ''}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
   <div
-    class="fixed top-0 left-0 w-screen h-svh overflow-auto bg-white/50 dark:bg-black/50
-    flex flex-col z-100 backdrop-blur-xs"
+    class="fixed top-0 left-0 w-screen h-svh overflow-hidden bg-white/50 dark:bg-black/50
+    flex flex-col z-100 backdrop-blur-xs touch-none"
     transition:fade={{ duration: 150 }}
-    onclick={() => history.back()}
+    onclick={handleBackgroundClick}
     onkeydown={(e) => {
       if (e.key == 'Escape') history.back()
+      else if (e.key == '+' || e.key == '=') zoomIn()
+      else if (e.key == '-') zoomOut()
+      else if (e.key == '0') resetView()
     }}
+    onwheel={handleWheel}
     use:trapFocus
   >
-    <img
-      width={800}
-      height={800}
-      src={page.state.openImage}
-      class={[
-        'max-w-full mx-auto my-auto overscroll-contain bg-white dark:bg-zinc-900',
-      ]}
-      transition:scale={{ start: 1.04, easing: backOut, duration: 250 }}
-      {alt}
-    />
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+      class="flex-1 flex items-center justify-center overflow-hidden min-h-0"
+      onclick={(e) => e.stopPropagation()}
+      onpointerdown={handlePointerDown}
+      onpointermove={handlePointerMove}
+      onpointerup={handlePointerUp}
+      onpointercancel={handlePointerUp}
+      ontouchstart={handleTouchStart}
+      ontouchmove={handleTouchMove}
+      ontouchend={handleTouchEnd}
+    >
+      <img
+        src={page.state.openImage}
+        class={[
+          'max-w-full max-h-full object-contain select-none',
+          dragging ? 'cursor-grabbing' : zoom > 1 ? 'cursor-grab' : 'cursor-zoom-in',
+        ]}
+        style="transform: translate({translateX}px, {translateY}px) scale({zoom}); transition: {dragging
+          ? 'none'
+          : 'transform 150ms ease-out'};"
+        transition:scaleTransition={{
+          start: 1.04,
+          easing: backOut,
+          duration: 250,
+        }}
+        ondblclick={(e) => {
+          e.stopPropagation()
+          zoom > 1 ? resetView() : setZoom(2)
+        }}
+        draggable="false"
+        {alt}
+      />
+    </div>
     <div class="sticky z-10 bottom-4 left-1/2 -translate-x-1/2 w-max">
       <Material
         class="gap-1 p-0.5 px-1 flex flex-row items-center"
@@ -56,6 +196,24 @@
         color="uniform"
         onclick={(e) => e.stopPropagation()}
       >
+        <Button
+          onclick={zoomOut}
+          color="tertiary"
+          size="square-lg"
+          rounding="pill"
+          aria-label="Zoom out"
+          icon={MagnifyingGlassMinus}
+          disabled={zoom <= MIN_ZOOM}
+        ></Button>
+        <Button
+          onclick={zoomIn}
+          color="tertiary"
+          size="square-lg"
+          rounding="pill"
+          aria-label="Zoom in"
+          icon={MagnifyingGlassPlus}
+          disabled={zoom >= MAX_ZOOM}
+        ></Button>
         <Button
           onclick={() => {
             navigator.clipboard.writeText(page.state?.openImage ?? '')

--- a/src/lib/ui/generic/ExpandableImage.svelte
+++ b/src/lib/ui/generic/ExpandableImage.svelte
@@ -10,179 +10,145 @@
     XMark,
   } from 'svelte-hero-icons/dist'
   import { backOut } from 'svelte/easing'
-  import { fade, scale as scaleTransition } from 'svelte/transition'
+  import { fade, scale } from 'svelte/transition'
   import { trapFocus } from 'trap-focus-svelte'
 
   export function showImage(url: string) {
-    pushState('', {
-      openImage: url,
-    })
+    pushState('', { openImage: url })
   }
-</script>
-
-<script lang="ts">
-  interface Props {
-    /**
-     * The full-resolution image URL
-     */
-    alt?: string
-  }
-
-  let { alt = '' }: Props = $props()
 
   const MIN_ZOOM = 1
   const MAX_ZOOM = 8
   const ZOOM_STEP = 1.5
+  const clamp = (value: number) => Math.min(Math.max(value, MIN_ZOOM), MAX_ZOOM)
+</script>
+
+<script lang="ts">
+  let { alt = '' }: { alt?: string } = $props()
 
   let zoom = $state(1)
-  let translateX = $state(0)
-  let translateY = $state(0)
+  let tx = $state(0)
+  let ty = $state(0)
   let dragging = $state(false)
-  let dragStartX = 0
-  let dragStartY = 0
-  let originX = 0
-  let originY = 0
-  let pinchStartDistance = 0
-  let pinchStartZoom = 1
 
-  function resetView() {
+  let drag = { x: 0, y: 0, tx: 0, ty: 0 }
+  let pinch = { distance: 0, zoom: 1 }
+
+  function reset() {
     zoom = 1
-    translateX = 0
-    translateY = 0
-  }
-
-  function clampZoom(value: number) {
-    return Math.min(Math.max(value, MIN_ZOOM), MAX_ZOOM)
+    tx = 0
+    ty = 0
   }
 
   function setZoom(next: number) {
-    const newZoom = clampZoom(next)
-    if (newZoom === 1) {
-      translateX = 0
-      translateY = 0
+    zoom = clamp(next)
+    if (zoom === 1) {
+      tx = 0
+      ty = 0
     }
-    zoom = newZoom
-  }
-
-  function zoomIn() {
-    setZoom(zoom * ZOOM_STEP)
-  }
-
-  function zoomOut() {
-    setZoom(zoom / ZOOM_STEP)
-  }
-
-  function handleWheel(e: WheelEvent) {
-    e.preventDefault()
-    const factor = e.deltaY < 0 ? 1.1 : 1 / 1.1
-    setZoom(zoom * factor)
-  }
-
-  function handlePointerDown(e: PointerEvent) {
-    if (zoom <= 1) return
-    dragging = true
-    dragStartX = e.clientX
-    dragStartY = e.clientY
-    originX = translateX
-    originY = translateY
-    ;(e.currentTarget as HTMLElement).setPointerCapture(e.pointerId)
-  }
-
-  function handlePointerMove(e: PointerEvent) {
-    if (!dragging) return
-    translateX = originX + (e.clientX - dragStartX)
-    translateY = originY + (e.clientY - dragStartY)
-  }
-
-  function handlePointerUp(e: PointerEvent) {
-    if (!dragging) return
-    dragging = false
-    ;(e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId)
-  }
-
-  function handleTouchStart(e: TouchEvent) {
-    if (e.touches.length === 2) {
-      e.preventDefault()
-      const dx = e.touches[0].clientX - e.touches[1].clientX
-      const dy = e.touches[0].clientY - e.touches[1].clientY
-      pinchStartDistance = Math.hypot(dx, dy)
-      pinchStartZoom = zoom
-    }
-  }
-
-  function handleTouchMove(e: TouchEvent) {
-    if (e.touches.length === 2 && pinchStartDistance > 0) {
-      e.preventDefault()
-      const dx = e.touches[0].clientX - e.touches[1].clientX
-      const dy = e.touches[0].clientY - e.touches[1].clientY
-      const distance = Math.hypot(dx, dy)
-      setZoom((distance / pinchStartDistance) * pinchStartZoom)
-    }
-  }
-
-  function handleTouchEnd(e: TouchEvent) {
-    if (e.touches.length < 2) pinchStartDistance = 0
-  }
-
-  function handleBackgroundClick() {
-    if (zoom > 1) {
-      resetView()
-      return
-    }
-    history.back()
   }
 
   $effect(() => {
-    if (!page.state.openImage) resetView()
+    if (!page.state.openImage) reset()
   })
+
+  function onWheel(e: WheelEvent) {
+    e.preventDefault()
+    setZoom(zoom * (e.deltaY < 0 ? 1.1 : 1 / 1.1))
+  }
+
+  function onPointerDown(e: PointerEvent) {
+    if (zoom <= 1) return
+    dragging = true
+    drag = { x: e.clientX, y: e.clientY, tx, ty }
+    ;(e.currentTarget as Element).setPointerCapture(e.pointerId)
+  }
+
+  function onPointerMove(e: PointerEvent) {
+    if (!dragging) return
+    tx = drag.tx + (e.clientX - drag.x)
+    ty = drag.ty + (e.clientY - drag.y)
+  }
+
+  function onPointerUp(e: PointerEvent) {
+    if (!dragging) return
+    dragging = false
+    ;(e.currentTarget as Element).releasePointerCapture(e.pointerId)
+  }
+
+  function onTouchStart(e: TouchEvent) {
+    if (e.touches.length !== 2) return
+    e.preventDefault()
+    const [a, b] = [e.touches[0], e.touches[1]]
+    pinch = {
+      distance: Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY),
+      zoom,
+    }
+  }
+
+  function onTouchMove(e: TouchEvent) {
+    if (e.touches.length !== 2 || pinch.distance === 0) return
+    e.preventDefault()
+    const [a, b] = [e.touches[0], e.touches[1]]
+    const d = Math.hypot(a.clientX - b.clientX, a.clientY - b.clientY)
+    setZoom((d / pinch.distance) * pinch.zoom)
+  }
+
+  function onTouchEnd(e: TouchEvent) {
+    if (e.touches.length < 2) pinch.distance = 0
+  }
+
+  function onBackgroundClick() {
+    if (zoom > 1) reset()
+    else history.back()
+  }
+
+  function onKey(e: KeyboardEvent) {
+    if (e.key === 'Escape') history.back()
+    else if (e.key === '+' || e.key === '=') setZoom(zoom * ZOOM_STEP)
+    else if (e.key === '-') setZoom(zoom / ZOOM_STEP)
+    else if (e.key === '0') reset()
+  }
 </script>
 
-{#if page.state.openImage || '' != ''}
+{#if page.state.openImage}
   <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <!-- svelte-ignore a11y_click_events_have_key_events -->
   <div
-    class="fixed top-0 left-0 w-screen h-svh overflow-hidden bg-white/50 dark:bg-black/50
-    flex flex-col z-100 backdrop-blur-xs touch-none"
+    class="fixed inset-0 w-screen h-svh overflow-hidden bg-white/50 dark:bg-black/50
+      flex flex-col z-100 backdrop-blur-xs touch-none"
     transition:fade={{ duration: 150 }}
-    onclick={handleBackgroundClick}
-    onkeydown={(e) => {
-      if (e.key == 'Escape') history.back()
-      else if (e.key == '+' || e.key == '=') zoomIn()
-      else if (e.key == '-') zoomOut()
-      else if (e.key == '0') resetView()
-    }}
-    onwheel={handleWheel}
+    onclick={onBackgroundClick}
+    onkeydown={onKey}
+    onwheel={onWheel}
     use:trapFocus
   >
-    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
     <div
-      class="flex-1 flex items-center justify-center overflow-hidden min-h-0"
+      class="flex-1 min-h-0 flex items-center justify-center overflow-hidden"
       onclick={(e) => e.stopPropagation()}
-      onpointerdown={handlePointerDown}
-      onpointermove={handlePointerMove}
-      onpointerup={handlePointerUp}
-      onpointercancel={handlePointerUp}
-      ontouchstart={handleTouchStart}
-      ontouchmove={handleTouchMove}
-      ontouchend={handleTouchEnd}
+      onpointerdown={onPointerDown}
+      onpointermove={onPointerMove}
+      onpointerup={onPointerUp}
+      onpointercancel={onPointerUp}
+      ontouchstart={onTouchStart}
+      ontouchmove={onTouchMove}
+      ontouchend={onTouchEnd}
     >
       <img
         src={page.state.openImage}
-        class={[
-          'max-w-full max-h-full object-contain select-none',
-          dragging ? 'cursor-grabbing' : zoom > 1 ? 'cursor-grab' : 'cursor-zoom-in',
-        ]}
-        style="transform: translate({translateX}px, {translateY}px) scale({zoom}); transition: {dragging
-          ? 'none'
-          : 'transform 150ms ease-out'};"
-        transition:scaleTransition={{
-          start: 1.04,
-          easing: backOut,
-          duration: 250,
-        }}
+        class="max-w-full max-h-full object-contain select-none"
+        class:cursor-grabbing={dragging}
+        class:cursor-grab={!dragging && zoom > 1}
+        class:cursor-zoom-in={zoom === 1}
+        style:transform="translate({tx}px, {ty}px) scale({zoom})"
+        style:transition={dragging ? 'none' : 'transform 150ms ease-out'}
+        transition:scale={{ start: 1.04, easing: backOut, duration: 250 }}
         ondblclick={(e) => {
           e.stopPropagation()
-          zoom > 1 ? resetView() : setZoom(2)
+          if (zoom > 1) reset()
+          else setZoom(2)
         }}
         draggable="false"
         {alt}
@@ -197,7 +163,7 @@
         onclick={(e) => e.stopPropagation()}
       >
         <Button
-          onclick={zoomOut}
+          onclick={() => setZoom(zoom / ZOOM_STEP)}
           color="tertiary"
           size="square-lg"
           rounding="pill"
@@ -206,7 +172,7 @@
           disabled={zoom <= MIN_ZOOM}
         ></Button>
         <Button
-          onclick={zoomIn}
+          onclick={() => setZoom(zoom * ZOOM_STEP)}
           color="tertiary"
           size="square-lg"
           rounding="pill"


### PR DESCRIPTION
## Summary
- Images in the viewer no longer overflow/scroll — they're constrained to `max-w-full max-h-full object-contain` so they fit the viewport.
- Added zoom (1x–8x) via mouse wheel, +/- buttons, double-click, pinch gesture, and `+`/`-`/`0` keyboard shortcuts.
- Added click-and-drag panning (pointer events) when zoomed in; background click resets zoom or closes if already at 1x.

## Test plan
- [ ] Open a tall image — confirm it fits the viewport with no scrollbars.
- [ ] Open a wide image — confirm it fits with no scrollbars.
- [ ] Scroll wheel zooms in/out; +/- buttons work; disabled at min/max.
- [ ] Double-click toggles between 1x and 2x.
- [ ] When zoomed, drag pans the image; click on background resets view.
- [ ] On touch device, pinch-to-zoom works.
- [ ] Escape and X button still close; share button still copies URL.