### PR TITLE
Fix certain elements not using the 'Browser' font

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -7,8 +7,8 @@
 @theme {
   --font-sans: sans-serif;
   --font-system: system-ui;
-  --font-display: Inter, system-ui, sans-serif;
-  --font-reading: Inter, system-ui, sans-serif;
+  --font-display: sans-serif;
+  --font-reading: sans-serif;
   --font-mono: monospace;
 
   --animate-pop-in: pop-in 0.8s cubic-bezier(0.075, 0.82, 0.165, 1) forwards;

--- a/src/routes/settings/app/+page.svelte
+++ b/src/routes/settings/app/+page.svelte
@@ -98,7 +98,7 @@
     {#snippet description()}
       <p>
         {$t('settings.app.lang.description')}
-        <Link href="/translators" highlight class="text-base font-semibold">
+        <Link href="/translators" highlight class="font-semibold">
           {$t('settings.app.lang.credits')}
         </Link>
       </p>


### PR DESCRIPTION
Setting 'Browser' in the typeface ("font") settings will not make every element to use the font dictated by the web browser as 'sans-serif' - some elements, mainly headers (post headers, page headers) will still use the Inter font.

This pull request changes the hard-coded Inter font at the global CSS vars related to font typefaces to `sans-serif` so browsers will pick it first, and then apply another font if the user has set it that way.